### PR TITLE
check creation timestamp for nil and minor cleanup for local testing

### DIFF
--- a/deployment.yml
+++ b/deployment.yml
@@ -22,7 +22,7 @@ spec:
             memory: 20Mi
         env:
           - name: MAX_POD_DURATION
-            value: 4m
+            value: 2m
           - name: POLL_INTERVAL
             value: 10s
           - name: CONTAINER_STATUSES

--- a/main.go
+++ b/main.go
@@ -67,11 +67,14 @@ func hasStatus(pod v1.Pod, containerStates []string) (bool, string) {
 			}
 		}
 	}
-	return false, pod.Status.Reason
+	return false, ""
 }
 
 func exceedsMaxDuration(pod v1.Pod, maxPodDuration time.Duration) bool {
 	cutoff := unversioned.Unix(time.Now().Add(-1*maxPodDuration).Unix(), 0)
+	if pod.Status.StartTime == nil {
+		return false
+	}
 	return pod.Status.StartTime.Before(cutoff)
 }
 

--- a/minikube-deploy.sh
+++ b/minikube-deploy.sh
@@ -2,6 +2,9 @@
 # minikube start
 # eval $(minikube docker-env)
 
+# delete old Deployment
+kubectl --context=minikube delete --filename deployment.yml
+
 # build the local binary
 rm pod-reaper
 go fmt
@@ -12,6 +15,5 @@ CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo
 docker rmi pod-reaper
 docker build --tag=pod-reaper .
 
-# delete any lingering deployment, create a new deployment
-kubectl --context=minikube delete --filename deployment.yml
+# create a new deployment
 kubectl --context=minikube apply --filename deployment.yml

--- a/options.go
+++ b/options.go
@@ -53,5 +53,11 @@ func options() Options {
 }
 
 func (options *Options) printOptions() {
-	fmt.Printf("%+v\n", options)
+	// write out the used environment variables
+	fmt.Printf("MAX_POD_DURATION: %s\n", options.maxPodDuration)
+	fmt.Printf("POLL_INTERVAL: %s\n", options.pollInterval)
+	fmt.Printf("CONTAINER_STATUSES: %s\n", strings.Join(options.containerStatuses, ", "))
+	fmt.Printf("EXCLUDE_LABEL_KEY: %s\n", options.excludeLabelKey)
+	fmt.Printf("EXCLUDE_LABEL_VALUE: %s\n", options.excludeLabelValue)
+	fmt.Printf("NAMESPACE: %s\n", options.namespace)
 }


### PR DESCRIPTION
Had someone run into a strange condition that I have been unable to reproduce locally (due to tricky timing of the condition). It's still a good practice to checks for nils where they are a possibility though... so proposing this as a change.

I have the user running a test build of pod-reaper to help determine is this was indeed the fix:
Please don't merge until I report back my findings!