### PR TITLE
Nil pointer fix

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright 2017 Target 
+Copyright 2017 Target Corporation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ specification (see `deployment.yml`). The configuration of the plugin is control
 variables:
 
 - `MAX_POD_DURATION` (default: "2h"): pods with an age greater than this duration will be reaped unless excluded
-- `POLL_INTERVAL` (default: "15s"): how often the pod reaper will check for pods to delete
+- `POLL_INTERVAL` (default: "1m"): how often the pod reaper will check for pods to delete
 - `CONTAINER_STATUSES` (default: ""): pods with a status included in this comma separated list (with no spaces) will be
  reaped unless exclude
 - `EXCLUDE_LABEL_KEY` (default: "pod-reaper"): pods with this key (and corresponding value) as a metadata label will be

--- a/deployment.yml
+++ b/deployment.yml
@@ -24,7 +24,7 @@ spec:
           - name: MAX_POD_DURATION
             value: 2m
           - name: POLL_INTERVAL
-            value: 10s
+            value: 30ms
           - name: CONTAINER_STATUSES
             value: ImagePullBackOff,ErrImagePull
           - name: NAMESPACE

--- a/deployment.yml
+++ b/deployment.yml
@@ -24,7 +24,7 @@ spec:
           - name: MAX_POD_DURATION
             value: 2m
           - name: POLL_INTERVAL
-            value: 30ms
+            value: 30s
           - name: CONTAINER_STATUSES
             value: ImagePullBackOff,ErrImagePull
           - name: NAMESPACE

--- a/main.go
+++ b/main.go
@@ -49,7 +49,8 @@ func reap(options Options) {
 			fmt.Println(message)
 			err := clientSet.Core().Pods(pod.ObjectMeta.Namespace).Delete(pod.ObjectMeta.Name, nil)
 			if err != nil {
-				panic(err)
+				// this could be a race condition (someone else deleted the pod)
+				fmt.Errorf(err.Error())
 			}
 		}
 	}

--- a/options.go
+++ b/options.go
@@ -44,7 +44,7 @@ func split(environmentVariable string) []string {
 func options() Options {
 	return Options{
 		maxPodDuration:    duration("MAX_POD_DURATION", "2h"),
-		pollInterval:      duration("POLL_INTERVAL", "15s"),
+		pollInterval:      duration("POLL_INTERVAL", "1m"),
 		containerStatuses: split("CONTAINER_STATUSES"),
 		excludeLabelKey:   environment("EXCLUDE_LABEL_KEY", "pod-reaper"),
 		excludeLabelValue: environment("EXCLUDE_LABEL_VALUE", "disabled"),

--- a/options_test.go
+++ b/options_test.go
@@ -16,7 +16,7 @@ func TestDefaultMaxPodDuration(test *testing.T) {
 }
 
 func TestDefaultPollInterval(test *testing.T) {
-	duration, err := time.ParseDuration("15s")
+	duration, err := time.ParseDuration("1m")
 	if err != nil {
 		test.Errorf(err.Error())
 	}


### PR DESCRIPTION
@JordanSussman This is another problem that I discovered along the way...

- changed default poll interval to 1 minutes
- updated logging of configuration
- log when a delete fails: in most cases this is not a problem as the only observed cases have been a result of the pod no longer being found (race condition between deciding to reap it and something else deleting the pod)
- updated the local deploy script to minikube
