### PR TITLE
Add support for ENV_REQUIRE_LABEL_(KEY|VALUE)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,12 @@
 FROM golang:1.7 AS build
 WORKDIR /go/src/github.com/target/pod-reaper
 ENV CGO_ENABLED=0 GOOS=linux
-COPY ./ ./
 RUN go get github.com/Masterminds/glide
+COPY glide.* ./
 RUN glide install --strip-vendor
-RUN go test . ./rules
+COPY *.go ./
+COPY rules/*.go ./rules/
+RUN go test $(glide nv)
 RUN go build -a -installsuffix go
 
 # Application

--- a/README.md
+++ b/README.md
@@ -9,13 +9,15 @@ Pod-Reaper is configurable through environment variables. The pod-reaper specifi
 - `RUN_DURATION` how long pod-reaper should run before exiting
 - `EXCLUDE_LABEL_KEY` pod metadata label (of key-value pair) that pod-reaper should exclude
 - `EXCLUDE_LABEL_VALUES` comma-separated list of metadata label values (of key-value pair) that pod-reaper should exclude
+- `REQUIRE_LABEL_KEY` pod metadata label (of key-value pair) that pod-reaper should require
+- `REQUIRE_LABEL_VALUES` comma-separated list of metadata label values (of key-value pair) that pod-reaper should require
 
 Additionally, at least one rule must be enabled, or the pod-reaper will error and exit. See the Rules section below for configuring and enabling rules.
 
 Example environment variables:
 ```
 # pod-reaper configuration
-NAMESAPCE=test
+NAMESPACE=test
 POLL_INTERVAL=30s
 RUN_DURATION=15m
 EXCLUDE_LABEL_KEY=pod-reaper
@@ -43,7 +45,11 @@ Controls the minimum duration that pod-reaper will run before intentionally exit
 #### `EXCLUDE_LABEL_KEY` and `EXCLUDE_LABEL_VALUES`
 These environment variables are used to build a label selector to exclude pods from reaping. The key must be a properly formed kubernetes label key. Values are a comma-separated (without whitespace) list of kubernetes label values. Setting exactly one of the key or values environment variables will result in an error.
 
-A pod will be exclude from the pod-reaper if the pod has a metadata label has a key corresponding to the pod-reaper's exclude label key, and that same metadata label has a value in the pod-reaper's list of excluded label values. This means that exclusion requires both the pod-reaper and pod to be configured in a compatible way.
+A pod will be excluded from the pod-reaper if the pod has a metadata label has a key corresponding to the pod-reaper's exclude label key, and that same metadata label has a value in the pod-reaper's list of excluded label values. This means that exclusion requires both the pod-reaper and pod to be configured in a compatible way.
+
+#### `REQUIRE_LABEL_KEY` and `REQUIRE_LABEL_VALUES`
+
+These environment variables build a label selector that pods must match in order to be reaped. Use them the same way as you would `EXCLUDE_LABEL_KEY` and `EXCLUDE_LABEL_VALUES`.
 
 ## Implemented Rules
 

--- a/deployment.yml
+++ b/deployment.yml
@@ -43,7 +43,7 @@ spec:
           # randomly flag 30% of pods whenever they are checked
           - name: CHAOS_CHANCE
             value: ".3"
-      - name: choas
+      - name: chaos
         image: target/pod-reaper:latest
         imagePullPolicy: Never # set to never for local minikube testing
         resources:

--- a/main.go
+++ b/main.go
@@ -26,8 +26,14 @@ func getPods(clientSet *kubernetes.Clientset, options options) *v1.PodList {
 	coreClient := clientSet.CoreV1()
 	pods := coreClient.Pods(options.namespace)
 	listOptions := v1.ListOptions{}
-	if options.labelExclusion != nil {
-		selector := labels.NewSelector().Add(*options.labelExclusion)
+	if options.labelExclusion != nil || options.labelRequirement != nil {
+		selector := labels.NewSelector()
+		if options.labelExclusion != nil {
+			selector = selector.Add(*options.labelExclusion)
+		}
+		if options.labelRequirement != nil {
+			selector = selector.Add(*options.labelRequirement)
+		}
 		listOptions.LabelSelector = selector.String()
 	}
 	podList, err := pods.List(listOptions)


### PR DESCRIPTION
Extend pod-reaper so that it also supports only reaping pods whose labels match those given in `ENV_REQUIRE_LABEL_(KEY|VALUE)`.

The key aspect of this change, wherein any label exclusions and label inclusions are AND'ed together, lies in this part of main.go:

```go
	listOptions := v1.ListOptions{}
	if options.labelExclusion != nil || options.labelRequirement != nil {
		selector := labels.NewSelector()
		if options.labelExclusion != nil {
			selector = selector.Add(*options.labelExclusion)
		}
		if options.labelRequirement != nil {
			selector = selector.Add(*options.labelRequirement)
		}
		listOptions.LabelSelector = selector.String()
	}
```

Additional items:

* Update Dockerfile so that layers are more likely to cache, and so that only go sources are copied into the build environment.
* Update Dockerfile so tests are invoked against any local packages, via `go test $(glide nv)`.
* Update `options_test.go` so that the valid label exclusion test checks the string generated by its requirement.