### PR TITLE
minor cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 # pod-reaper: kills pods dead
 
-## 2.0.0
+### 1.1.0
+- added ability to only reap pods with specified labels
+
+## 1.0.0
 - redesign of the reaper to be built on modular rules
     - rules must implement two methods `load()` and `shouldReap(pod)`
     - rules determine whether or not they get loaded at runtime via environment variables
     - pods will only be reaped if all rules are met
 - major refactoring for testability
-
-## 1.0.0
-Initial release 

--- a/Dockerfile-minikube
+++ b/Dockerfile-minikube
@@ -1,0 +1,5 @@
+# including this because default minikube drivers do not yet support multistage docker builds
+# this will only be used for minikube
+FROM scratch
+COPY pod-reaper /
+CMD ["/pod-reaper"]

--- a/deployment.yml
+++ b/deployment.yml
@@ -24,7 +24,7 @@ spec:
             cpu: 20m
             memory: 20Mi
         # this configuration looks at all pods in the "default" namespace without the label pod-reaper: disabled and
-        # will delete 30% of found pods thare have been running for more than 2 minutes
+        # will delete 30% of found pods that have been running for more than 2 minutes
         env:
           # only look for pods in the "default" namespace
           - name: NAMESPACE

--- a/main.go
+++ b/main.go
@@ -45,7 +45,7 @@ func getPods(clientSet *kubernetes.Clientset, options options) *v1.PodList {
 
 func reap(clientSet *kubernetes.Clientset, pod v1.Pod, reason string) {
 	fmt.Printf("Reaping Pod %s because %s\n", pod.Name, reason)
-	err := clientSet.Core().Pods(pod.Namespace).Delete(pod.Name, nil)
+	err := clientSet.CoreV1().Pods(pod.Namespace).Delete(pod.Name, nil)
 	if err != nil {
 		// log the error, but continue on
 		fmt.Fprintf(os.Stderr, "unable to delete pod %s because %s", pod.Name, err)

--- a/minikube-deploy.sh
+++ b/minikube-deploy.sh
@@ -4,16 +4,16 @@
 # eval $(minikube docker-env)
 
 # delete old Deployment
-kubectl --context=minikube delete --filename deployment.yml
+kubectl --context=minikube delete --filename deployment.yml --ignore-not-found
 
 # build the local binary
 go fmt
 go test . ./rules
-CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo
+CGO_ENABLED=0 GOOS=linux GOARCH=amd go build -a -installsuffix cgo
 
 # build the docker container
 docker rmi pod-reaper
-docker build --tag=target/pod-reaper:latest .
+docker build --file Dockerfile-minikube --tag=target/pod-reaper:latest .
 
 # create a new deployment
 kubectl --context=minikube apply --filename deployment.yml


### PR DESCRIPTION
Series of small cleanups:

- updated depreciated calls into the kubernetes client library
- corrected the version numbers in the change log
- correct typo in the deployment.yaml file
- cleaned up minikube deployment script

Note that this included adding another dockerfile specifically for minikube. I did a machine re-image recently and the latest version of minikube does not start a virtualbox docker host with support of multistage builds...

https://github.com/kubernetes/minikube/pull/1542