### PR TITLE
correct dockerhub url

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![license](https://img.shields.io/github/license/mashape/apistatus.svg)](LICENSE)
 [![release](https://img.shields.io/github/release/target/pod-reaper.svg)](https://github.com/target/pod-reaper/releases/latest)
-[![docker](https://img.shields.io/docker/automated/target/pod-reaper.svg)](docker)
+[![docker](https://img.shields.io/docker/automated/target/pod-reaper.svg)](https://hub.docker.com/r/target/pod-reaper)
 
 A rules based pod killing container. Pod-Reaper was designed to kill pods that meet specific conditions. See the "Implemented Rules" section below for details on specific rules.
 


### PR DESCRIPTION
Would help if the badge links to Dockerhub instead of a nonexistent file.