### PR TITLE
adding grace period feature for pod killing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # pod-reaper: kills pods dead
 
+### 2.1.0
+
+- added configurable `GRACE_PERIOD` to control soft vs hard pod kills
+
 ## 2.0.0
 
 - removed `POLL_INTERVAL` environment variable in favor of cron schedule
@@ -8,7 +12,7 @@
 - refactored packages for clarity
 - testing refactor for clarity
 
-## 1.1.0
+### 1.1.0
 
 - added ability to only reap pods with specified labels
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A rules based pod killing container. Pod-Reaper was designed to kill pods that m
 Pod-Reaper is configurable through environment variables. The pod-reaper specific environment variables are:
 
 - `NAMESPACE` the kubernetes namespace where pod-reaper should look for pods
+- `GRACE_PERIOD` duration that pods should be given to shut down before hard killing the pod
 - `SCHEDULE` schedule for when pod-reaper should look for pods to reap
 - `RUN_DURATION` how long pod-reaper should run before exiting
 - `EXCLUDE_LABEL_KEY` pod metadata label (of key-value pair) that pod-reaper should exclude
@@ -39,6 +40,12 @@ CHAOS_CHANCE=.001
 Default value: "" (which will look at ALL namespaces)
 
 Controls which kubernetes namespace the pod-reaper is in scope for the pod-reaper. Note that the pod-reaper uses an `InClusterConfig` which makes use of the service account that kubernetes gives to its pods. Only pods (and namespaces) accessible to this service account will be visible to the pod-reaper.
+
+### `GRACE_PERIOD`
+
+Default value: nil (indicates to the use the default specified for pods)
+
+Controls the grace period between a soft pod termination and a hard termination. This will determine the time between when the pod's containers are send a `SIGTERM` signal and when they are sent a `SIGKILL` signal. The format follows the go-lang `time.duration` format (example: "1h15m30s"). A duration of `0s` can be considered a hard kill of the pod.
 
 ### `SCHEDULE`
 

--- a/reaper/main.go
+++ b/reaper/main.go
@@ -1,101 +1,12 @@
 package main
 
 import (
-	"fmt"
-	"time"
-
-	"github.com/robfig/cron"
 	"github.com/sirupsen/logrus"
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/pkg/api/v1"
-	"k8s.io/client-go/rest"
 )
-
-func clientSet() *kubernetes.Clientset {
-	config, err := rest.InClusterConfig()
-	if err != nil {
-		panic(err)
-	}
-	clientSet, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		panic(err)
-	}
-	return clientSet
-}
-
-func getPods(clientSet *kubernetes.Clientset, options options) *v1.PodList {
-	coreClient := clientSet.CoreV1()
-	pods := coreClient.Pods(options.namespace)
-	listOptions := v1.ListOptions{}
-	if options.labelExclusion != nil || options.labelRequirement != nil {
-		selector := labels.NewSelector()
-		if options.labelExclusion != nil {
-			selector = selector.Add(*options.labelExclusion)
-		}
-		if options.labelRequirement != nil {
-			selector = selector.Add(*options.labelRequirement)
-		}
-		listOptions.LabelSelector = selector.String()
-	}
-	podList, err := pods.List(listOptions)
-	if err != nil {
-		panic(err)
-	}
-	return podList
-}
-
-func reap(clientSet *kubernetes.Clientset, pod v1.Pod, reasons []string) {
-	logrus.WithFields(logrus.Fields{
-		"pod":     pod.Name,
-		"reasons": reasons,
-	}).Info("reaping pod")
-	err := clientSet.CoreV1().Pods(pod.Namespace).Delete(pod.Name, nil)
-	if err != nil {
-		// log the error, but continue on: often times something else has already deleted the pod
-		logrus.WithFields(logrus.Fields{
-			"pod":    pod.Name,
-			"reason": err.Error(),
-		}).Warn("failed to reap pod")
-	}
-}
-
-func scytheCycle(clientSet *kubernetes.Clientset, options options) {
-	logrus.Info("executing reap cycle")
-	pods := getPods(clientSet, options)
-	for _, pod := range pods.Items {
-		shouldReap, reasons := options.rules.ShouldReap(pod)
-		if shouldReap {
-			reap(clientSet, pod, reasons)
-		}
-	}
-}
 
 func main() {
 	logrus.SetFormatter(&logrus.JSONFormatter{})
-	clientSet := clientSet()
-	options, err := loadOptions()
-	if err != nil {
-		panic(err)
-	}
-	runForever := options.runDuration == 0
-
-	schedule := cron.New()
-	err = schedule.AddFunc(options.schedule, func() {
-		scytheCycle(clientSet, options)
-	})
-
-	if err != nil {
-		panic(fmt.Errorf("unable to create cron schedule: '%s' %s", options.schedule, err.Error()))
-	}
-
-	schedule.Start()
-
-	if runForever {
-		select {} // should only fail if no routine can make progress
-	} else {
-		time.Sleep(options.runDuration)
-		schedule.Stop()
-	}
+	reaper := newReaper()
+	reaper.harvest()
 	logrus.Info("pod reaper is exiting")
 }

--- a/reaper/options.go
+++ b/reaper/options.go
@@ -46,9 +46,6 @@ func gracePeriod() (*int64, error) {
 		return nil, fmt.Errorf("invalid %s: %s", envGracePeriod, err)
 	}
 	seconds := int64(duration.Seconds())
-	if seconds < 0 {
-		return nil, fmt.Errorf("grace period must translate to a non-negative number of seconds: %s", envGracePeriod)
-	}
 	return &seconds, nil
 }
 

--- a/reaper/options_test.go
+++ b/reaper/options_test.go
@@ -29,6 +29,27 @@ func TestOptions(t *testing.T) {
 			assert.Equal(t, "test-namespace", namespace)
 		})
 	})
+	t.Run("grace period", func(t *testing.T) {
+		t.Run("default", func(t *testing.T) {
+			os.Clearenv()
+			gracePeriod, err := gracePeriod()
+			assert.NoError(t, err)
+			assert.Nil(t, gracePeriod)
+		})
+		t.Run("valid", func(t *testing.T) {
+			os.Clearenv()
+			os.Setenv(envGracePeriod, "1m53s999ms")
+			gracePeriod, err := gracePeriod()
+			assert.NoError(t, err)
+			assert.Equal(t, int64(113), *gracePeriod)
+		})
+		t.Run("invalid", func(t *testing.T) {
+			os.Clearenv()
+			os.Setenv(envGracePeriod, "invalid")
+			_, err := gracePeriod()
+			assert.Error(t, err)
+		})
+	})
 	t.Run("schedule", func(t *testing.T) {
 		t.Run("default", func(t *testing.T) {
 			os.Clearenv()

--- a/reaper/reaper.go
+++ b/reaper/reaper.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"errors"
+	"github.com/robfig/cron"
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/pkg/api/v1"
+	"k8s.io/client-go/rest"
+	"time"
+)
+
+type reaper struct {
+	clientSet *kubernetes.Clientset
+	options   options
+}
+
+func newReaper() reaper {
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		panic(err)
+	}
+	clientSet, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		panic(err)
+	}
+	if clientSet == nil {
+		panic(errors.New("kubernetes client set cannot be nil"))
+	}
+	options, err := loadOptions()
+	if err != nil {
+		panic(err)
+	}
+	return reaper{
+		clientSet: clientSet,
+		options:   options,
+	}
+}
+
+func (reaper reaper) getPods() *v1.PodList {
+	coreClient := reaper.clientSet.CoreV1()
+	pods := coreClient.Pods(reaper.options.namespace)
+	listOptions := v1.ListOptions{}
+	if reaper.options.labelExclusion != nil || reaper.options.labelRequirement != nil {
+		selector := labels.NewSelector()
+		if reaper.options.labelExclusion != nil {
+			selector = selector.Add(*reaper.options.labelExclusion)
+		}
+		if reaper.options.labelRequirement != nil {
+			selector = selector.Add(*reaper.options.labelRequirement)
+		}
+		listOptions.LabelSelector = selector.String()
+	}
+	podList, err := pods.List(listOptions)
+	if err != nil {
+		panic(err)
+	}
+	return podList
+}
+
+func (reaper reaper) reapPod(pod v1.Pod, reasons []string) {
+	logrus.WithFields(logrus.Fields{
+		"pod":     pod.Name,
+		"reasons": reasons,
+	}).Info("reaping pod")
+	deleteOptions := &v1.DeleteOptions{
+		GracePeriodSeconds: reaper.options.gracePeriod,
+	}
+	err := reaper.clientSet.CoreV1().Pods(pod.Namespace).Delete(pod.Name, deleteOptions)
+	if err != nil {
+		// log the error, but continue on
+		fmt.Fprintf(os.Stderr, "unable to delete pod %s: %s", pod.Name, err)
+	}
+}
+
+func (reaper reaper) scytheCycle() {
+	pods := reaper.getPods()
+	for _, pod := range pods.Items {
+		shouldReap, reason := reaper.options.rules.ShouldReap(pod)
+		if shouldReap {
+			reaper.reapPod(pod, reason)
+		}
+	}
+}
+
+func (reaper reaper) harvest() {
+	runForever := reaper.options.runDuration == 0
+	schedule := cron.New()
+	err := schedule.AddFunc(reaper.options.schedule, func() {
+		reaper.scytheCycle()
+	})
+
+	if err != nil {
+		panic(fmt.Errorf("unable to create cron schedule: '%s' %s", reaper.options.schedule, err.Error()))
+	}
+
+	schedule.Start()
+
+	if runForever {
+		select {} // should only fail if no routine can make progress
+	} else {
+		time.Sleep(reaper.options.runDuration)
+		schedule.Stop()
+	}
+}

--- a/reaper/reaper.go
+++ b/reaper/reaper.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"time"
 
 	"github.com/robfig/cron"
 	"github.com/sirupsen/logrus"
@@ -9,7 +9,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/rest"
-	"time"
 )
 
 type reaper struct {
@@ -25,7 +24,7 @@ func newReaper() reaper {
 	}
 	clientSet, err := kubernetes.NewForConfig(config)
 	if err != nil {
-		logrus.WithError(err).Panic("unable to get client set for in cluster kubernetest config")
+		logrus.WithError(err).Panic("unable to get client set for in cluster kubernetes config")
 		panic(err)
 	}
 	if clientSet == nil {
@@ -102,7 +101,8 @@ func (reaper reaper) harvest() {
 	})
 
 	if err != nil {
-		panic(fmt.Errorf("unable to create cron schedule: '%s' %s", reaper.options.schedule, err.Error()))
+		logrus.WithError(err).Panic("unable to create cron schedule: " + reaper.options.schedule)
+		panic(err)
 	}
 
 	schedule.Start()

--- a/rules/rules.go
+++ b/rules/rules.go
@@ -53,7 +53,7 @@ func LoadRules() (Rules, error) {
 // ShouldReap takes a pod and return whether or not the pod should be reaped based on this rule.
 // Also includes a message describing why the pod was flagged for reaping.
 func (rules Rules) ShouldReap(pod v1.Pod) (bool, []string) {
-	reasons := []string{}
+	var reasons []string
 	for _, rule := range rules.LoadedRules {
 		reap, reason := rule.ShouldReap(pod)
 		if !reap {


### PR DESCRIPTION
When pod reaper "reaps" a pod: kubernetes is sending a `SIGTERM` to each container process. With the addition of the `GRACE_PERIOD` environment variable, we can configure the duration between the `SIGTERM` and `SIGKILL` sent by kubernetes. A `GRACE_PERIOD=0s` would effectively be a "hard kill" of the container.

If this value is NOT set, it defaults the grace period to whatever kubernetes views as the default for for pods. This is identical to the behavior prior to implementing this feature, which makes it perfectly backwards compatible.

resolves #31 