### PR TITLE
Flexible logging formats

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build
-FROM golang:1.7 AS build
+FROM golang:1.9 AS build
 WORKDIR /go/src/github.com/target/pod-reaper
 ENV CGO_ENABLED=0 GOOS=linux
 RUN go get github.com/Masterminds/glide

--- a/README.md
+++ b/README.md
@@ -116,6 +116,12 @@ Messages this level and above will be logged. Available logging levels: Debug, I
 {"level":"info","msg":"pod reaper is exiting","time":"2017-10-18T17:10:46Z"}
 ```
 
+### `LOG_FORMAT`
+
+Default value: Logrus
+
+This environment variable modifies the structured log format for easy ingestion into different logging systems, including Stackdriver via the Fluentd format. Available formats: Logrus, Fluentd
+
 ## Implemented Rules
 
 ### Chaos Chance

--- a/glide.lock
+++ b/glide.lock
@@ -27,9 +27,9 @@ imports:
   subpackages:
   - spew
 - name: github.com/docker/distribution
-  version: cd27f179f2c10c5d300e6d09025b538c475b0d51
+  version: 2461543d988979529609e8cb6fca9ca190dc48da
   subpackages:
-  - digest
+  - digestset
   - reference
 - name: github.com/emicklei/go-restful
   version: 09691a3b6378b740595c1002f40c34dd5f218a22
@@ -61,14 +61,20 @@ imports:
   version: 44d81051d367757e1c7c6a5a86423ece9afcf63c
 - name: github.com/jonboulle/clockwork
   version: 72f9bd7c4e0c2a40055ab3d0f09654f730cce982
+- name: github.com/joonix/log
+  version: f5f056244ba320717491aa9a073a2cb4fdc2ff30
 - name: github.com/juju/ratelimit
   version: 77ed1c8a01217656d2080ad51981f6e99adaa177
+- name: github.com/konsorten/go-windows-terminal-sequences
+  version: f55edac94c9bbba5d6182a4be46d86a2c9b5b50e
 - name: github.com/mailru/easyjson
   version: d5b7844b561a7bc640052f1b935f7b800330d7e0
   subpackages:
   - buffer
   - jlexer
   - jwriter
+- name: github.com/opencontainers/go-digest
+  version: dd78d7521eee4ff6016d9b6273dc328308ac5a1c
 - name: github.com/pborman/uuid
   version: ca53cad383cad2479bbba7f7a1a05797ec1386e4
 - name: github.com/PuerkitoBio/purell
@@ -110,10 +116,9 @@ imports:
   - jws
   - jwt
 - name: golang.org/x/sys
-  version: 8f0908ab3b2457e2e15403d3697c9ef5cb4b57a9
+  version: d5e6a3e2c0ae16fc7480523ebcb7fd4dd3215489
   subpackages:
   - unix
-  - windows
 - name: golang.org/x/text
   version: 2910a502d2bf9e43193af9d68ca516529614eed3
   subpackages:

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 3826f92773876f22041c02fcfbb92ca5d159b4272386522f524264ccfcb9904d
-updated: 2017-10-18T11:29:48.942379515-05:00
+hash: 956aef653d24b11b29e6ac247018b5d5ce43e47395a1637b9dd0bd3fee9c4e5a
+updated: 2020-02-28T17:08:38.4997436Z
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -23,7 +23,7 @@ imports:
   - httputil
   - timeutil
 - name: github.com/davecgh/go-spew
-  version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
+  version: 346938d642f2ec3594ed81d874461961cd0faa76
   subpackages:
   - spew
 - name: github.com/docker/distribution
@@ -82,23 +82,19 @@ imports:
 - name: github.com/PuerkitoBio/urlesc
   version: 5bd2802263f21d8788851d5305584c82a5c75d7e
 - name: github.com/robfig/cron
-  version: b024fc5ea0e34bc3f83d9941c8d60b0622bfaca4
+  version: b41be1df696709bb6395fe435af20370037c0b4c
 - name: github.com/sirupsen/logrus
-  version: f006c2ac4710855cf0f916dd6b77acf6b048dc6e
+  version: 839c75faf7f98a33d445d181f3018b5c3409a45e
 - name: github.com/spf13/pflag
   version: 9ff6c6923cfffbcd502984b8e0c80539a94968b7
 - name: github.com/stretchr/testify
-  version: 69483b4bd14f5845b5a1e55bca19e954e827f1d0
+  version: 3ebf1ddaeb260c4b1ae502a01c7844fa8c1fa0e9
   subpackages:
   - assert
 - name: github.com/ugorji/go
   version: ded73eae5db7e7a0ef6f55aace87a2873c5d2b74
   subpackages:
   - codec
-- name: golang.org/x/crypto
-  version: ed5229da99e3a6df35c756cd64b6982d19505d86
-  subpackages:
-  - ssh/terminal
 - name: golang.org/x/net
   version: f2499483f923065a842d38eb4c7f1927e6fc6e6d
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -25,4 +25,6 @@ import:
 - package: github.com/docker/distribution
   version: ^2.7.1
 - package: github.com/joonix/log
-  version: v0.1
+  version: =v0.1
+- package: github.com/davecgh/go-spew
+  version: =v1.1.0

--- a/glide.yaml
+++ b/glide.yaml
@@ -22,3 +22,7 @@ import:
   version: ^1.0.0
 - package: github.com/sirupsen/logrus
   version: ^1.0.0
+- package: github.com/docker/distribution
+  version: ^2.7.1
+- package: github.com/joonix/log
+  version: v0.1

--- a/reaper/main.go
+++ b/reaper/main.go
@@ -10,6 +10,7 @@ import (
 const envLogLevel = "LOG_LEVEL"
 const envLogFormat = "LOG_FORMAT"
 const fluentdFormat = "Fluentd"
+const logrusFormat = "Logrus"
 const defaultLogLevel = logrus.InfoLevel
 
 func main() {
@@ -40,7 +41,7 @@ func getLogLevel() logrus.Level {
 
 func getLogFormat() logrus.Formatter {
 	formatString, exists := os.LookupEnv(envLogFormat)
-	if !exists {
+	if !exists || formatString == logrusFormat {
 		return &logrus.JSONFormatter{}
 	} else if formatString == fluentdFormat {
 		return &joonix.FluentdFormatter{}

--- a/reaper/main.go
+++ b/reaper/main.go
@@ -3,16 +3,20 @@ package main
 import (
 	"os"
 
+	joonix "github.com/joonix/log"
 	"github.com/sirupsen/logrus"
 )
 
 const envLogLevel = "LOG_LEVEL"
+const envLogFormat = "LOG_FORMAT"
+const fluentdFormat = "Fluentd"
 const defaultLogLevel = logrus.InfoLevel
 
 func main() {
 	logLevel := getLogLevel()
 	logrus.SetLevel(logLevel)
-	logrus.SetFormatter(&logrus.JSONFormatter{})
+	logFormat := getLogFormat()
+	logrus.SetFormatter(logFormat)
 
 	reaper := newReaper()
 	reaper.harvest()
@@ -32,4 +36,16 @@ func getLogLevel() logrus.Level {
 	}
 
 	return level
+}
+
+func getLogFormat() logrus.Formatter {
+	formatString, exists := os.LookupEnv(envLogFormat)
+	if !exists {
+		return &logrus.JSONFormatter{}
+	} else if formatString == fluentdFormat {
+		return &joonix.FluentdFormatter{}
+	} else {
+		logrus.Errorf("unknown %s: %v", envLogFormat, formatString)
+		return &logrus.JSONFormatter{}
+	}
 }

--- a/reaper/main_test.go
+++ b/reaper/main_test.go
@@ -56,6 +56,12 @@ func TestGetLogFormat(t *testing.T) {
 		format := getLogFormat()
 		assert.Equal(t, reflect.TypeOf(format), reflect.TypeOf(&logrus.JSONFormatter{}))
 	})
+	t.Run("logrus", func(t *testing.T) {
+		os.Clearenv()
+		os.Setenv(envLogFormat, "Logrus")
+		format := getLogFormat()
+		assert.Equal(t, reflect.TypeOf(format), reflect.TypeOf(&logrus.JSONFormatter{}))
+	})
 	t.Run("fluentd", func(t *testing.T) {
 		os.Clearenv()
 		os.Setenv(envLogFormat, "Fluentd")

--- a/reaper/main_test.go
+++ b/reaper/main_test.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"os"
+	"reflect"
 	"testing"
 
+	joonix "github.com/joonix/log"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
@@ -40,4 +42,24 @@ func TestGetLogLevel(t *testing.T) {
 			assert.Equal(t, level, tt.level)
 		})
 	}
+}
+
+func TestGetLogFormat(t *testing.T) {
+	t.Run("default not set", func(t *testing.T) {
+		os.Clearenv()
+		format := getLogFormat()
+		assert.Equal(t, reflect.TypeOf(format), reflect.TypeOf(&logrus.JSONFormatter{}))
+	})
+	t.Run("default invalid", func(t *testing.T) {
+		os.Clearenv()
+		os.Setenv(envLogFormat, "foo")
+		format := getLogFormat()
+		assert.Equal(t, reflect.TypeOf(format), reflect.TypeOf(&logrus.JSONFormatter{}))
+	})
+	t.Run("fluentd", func(t *testing.T) {
+		os.Clearenv()
+		os.Setenv(envLogFormat, "Fluentd")
+		format := getLogFormat()
+		assert.Equal(t, reflect.TypeOf(format), reflect.TypeOf(&joonix.FluentdFormatter{}))
+	})
 }


### PR DESCRIPTION
This is a PR with a possible solution for issue #47 

The PR adds a new environment variable that allows a logging format to be specified, optionally allowing logs to be generated using the correct fields for the fluentd collector.

I had to pin a few dependencies and update Go to 1.9 to get the build and test to run. I'd be happy to help convert the repo to a module and a current version of Go if that would be useful.