### PR TITLE
address cron job confusion and update dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,30 +1,36 @@
 # pod-reaper: kills pods dead
 
+### 2.6.0
+- adjusted cron `SCHEDULE` for optional seconds, non optional day of week
+
+### 2.5.0
+- added multiple logging formats
+
+### 2.4.1
+- added configurable `LOG_LEVEL`
+
+### 2.4.0
+- added `UNREADY` rule to kill pods based on duration of time not passing readiness checks
+
 ### 2.3.0
 - added `POD_STATUSES` rule (can now filter/kill `Evicted` pods)
 
 ### 2.2.0
-
 - added configurable `GRACE_PERIOD` to control soft vs hard pod kills
 
 ### 2.1.0
-
 - Added logging via [logrus](https://github.com/sirupsen/logrus)
 
 ## 2.0.0
-
 - removed `POLL_INTERVAL` environment variable in favor of cron schedule
 - added `SCHEDULE` environment variable to control when pods are inspected for reaping
   - makes use of https://godoc.org/github.com/robfig/cron
 - refactored packages for clarity
 - testing refactor for clarity
-
 ### 1.1.0
-
 - added ability to only reap pods with specified labels
 
 ## 1.0.0
-
 - redesign of the reaper to be built on modular rules
   - rules must implement two methods `load()` and `shouldReap(pod)`
   - rules determine whether or not they get loaded at runtime via environment variables

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,12 @@
 # Build
-FROM golang:1.9 AS build
+FROM golang:1.14 AS build
 WORKDIR /go/src/github.com/target/pod-reaper
 ENV CGO_ENABLED=0 GOOS=linux
-RUN go get github.com/Masterminds/glide
-COPY glide.* ./
-RUN glide install --strip-vendor
-COPY reaper/*.go ./reaper/
-COPY rules/*.go ./rules/
-RUN go test $(glide nv)
-RUN go build -o pod-reaper -a -installsuffix go ./reaper
+COPY ./ ./
+RUN go get github.com/Masterminds/glide \
+ && glide install --strip-vendor \
+ && go test $(glide nv) \
+ && go build -o pod-reaper -a -installsuffix go ./reaper
 
 # Application
 FROM scratch

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Controls the grace period between a soft pod termination and a hard termination.
 
 Default value: "@every 1m"
 
-Controls how frequently pod-reaper queries kubernetes for pods. The format follows the upstream cron library https://godoc.org/github.com/robfig/cron. For most use cases, the interval format `@every 1h2m3s` is sufficient. But more complex use cases can make use of the `* * * * *` notation.
+Controls how frequently pod-reaper queries kubernetes for pods. The format follows the upstream cron library https://godoc.org/github.com/robfig/cron. For most use cases, the interval format `@every 1h2m3s` is sufficient. But more complex use cases can make use of the `* * * * *` notation. The cron parser used can optionally support seconds if a sixth parameter is add. `12 * * * * *` for example will run on the 12th second of every minute.
 
 ### `RUN_DURATION`
 

--- a/examples/complex-deployment.yml
+++ b/examples/complex-deployment.yml
@@ -99,6 +99,9 @@ spec:
           # randomly flag 30% of pods whenever they are checked
           - name: CHAOS_CHANCE
             value: ".3"
+          # increase logging
+          - name: LOG_LEVEL
+            value: debug
 
       - name: chaos # reaper 2
         image: target/pod-reaper
@@ -110,12 +113,15 @@ spec:
             cpu: 20m
             memory: 20Mi
         env:
-          # cron job based schedule
+          # cron job based schedule (with seconds)
           - name: SCHEDULE
-            value: "0/5 * * * *"
+            value: "15 * * * * *"
           # randomly flag 5% of pods whenever they are checked
           - name: CHAOS_CHANCE
             value: ".05"
+          # increase logging
+          - name: LOG_LEVEL
+            value: debug
 
       - name: error # reaper 3
         image: target/pod-reaper
@@ -130,7 +136,10 @@ spec:
         env:
           # check pods every 3 min
           - name: SCHEDULE
-            value: "@every 3m"
+            value: "0/3 * * * *"
           # check if container status is in the set  { Error, ErrImagePull, ImagePullBackOff }
           - name: CONTAINER_STATUSES
             value: "Error,ErrImagePull,ImagePullBackOff"
+          # increase logging
+          - name: LOG_LEVEL
+            value: debug

--- a/glide.lock
+++ b/glide.lock
@@ -1,223 +1,155 @@
-hash: 956aef653d24b11b29e6ac247018b5d5ce43e47395a1637b9dd0bd3fee9c4e5a
-updated: 2020-02-28T17:08:38.4997436Z
+hash: 64cba7646336cbab1af45f8c55b2a540a6ccfbe3ea812536f1a898408a3d6e00
+updated: 2020-03-27T07:38:24.551656556-05:00
 imports:
-- name: cloud.google.com/go
-  version: 3b1ae45394a234c385be014e9a488f2bb6eef821
-  subpackages:
-  - compute/metadata
-  - internal
-- name: github.com/blang/semver
-  version: 31b736133b98f26d5e078ec9eb591666edfd091f
-- name: github.com/coreos/go-oidc
-  version: 5644a2f50e2d2d5ba0b474bc5bc55fea1925936d
-  subpackages:
-  - http
-  - jose
-  - key
-  - oauth2
-  - oidc
-- name: github.com/coreos/pkg
-  version: fa29b1d70f0beaddd4c7021607cc3c3be8ce94b8
-  subpackages:
-  - health
-  - httputil
-  - timeutil
 - name: github.com/davecgh/go-spew
-  version: 346938d642f2ec3594ed81d874461961cd0faa76
+  version: 8991bc29aa16c548c550c7ff78260e27b9ab7c73
   subpackages:
   - spew
 - name: github.com/docker/distribution
   version: 2461543d988979529609e8cb6fca9ca190dc48da
-  subpackages:
-  - digestset
-  - reference
-- name: github.com/emicklei/go-restful
-  version: 09691a3b6378b740595c1002f40c34dd5f218a22
-  subpackages:
-  - log
-  - swagger
-- name: github.com/ghodss/yaml
-  version: 73d445a93680fa1a78ae23a5839bad48f32ba1ee
-- name: github.com/go-openapi/jsonpointer
-  version: 46af16f9f7b149af66e5d1bd010e3574dc06de98
-- name: github.com/go-openapi/jsonreference
-  version: 13c6e3589ad90f49bd3e3bbe2c2cb3d7a4142272
-- name: github.com/go-openapi/spec
-  version: 6aced65f8501fe1217321abf0749d354824ba2ff
-- name: github.com/go-openapi/swag
-  version: 1d0bd113de87027671077d3c71eb3ac5d7dbba72
 - name: github.com/gogo/protobuf
-  version: c0656edd0d9eab7c66d1eb0c568f9039345796f7
+  version: 65acae22fc9d1fe290b33faa2bd64cdc20a463a0
   subpackages:
   - proto
   - sortkeys
-- name: github.com/golang/glog
-  version: 44145f04b68cf362d9c4df2182967c2275eaefed
 - name: github.com/golang/protobuf
-  version: 4bd1920723d7b7c925de087aa32e2187708897f7
+  version: 6c65a5562fc06764971b7c5d05c76c75e84bdbf7
   subpackages:
   - proto
+  - ptypes
+  - ptypes/any
+  - ptypes/duration
+  - ptypes/timestamp
 - name: github.com/google/gofuzz
-  version: 44d81051d367757e1c7c6a5a86423ece9afcf63c
-- name: github.com/jonboulle/clockwork
-  version: 72f9bd7c4e0c2a40055ab3d0f09654f730cce982
+  version: f140a6486e521aad38f5917de355cbf147cc0496
+- name: github.com/googleapis/gnostic
+  version: 0c5108395e2debce0d731cf0287ddf7242066aba
+  subpackages:
+  - OpenAPIv2
+  - compiler
+  - extensions
 - name: github.com/joonix/log
   version: f5f056244ba320717491aa9a073a2cb4fdc2ff30
-- name: github.com/juju/ratelimit
-  version: 77ed1c8a01217656d2080ad51981f6e99adaa177
+- name: github.com/json-iterator/go
+  version: 03217c3e97663914aec3faafde50d081f197a0a2
 - name: github.com/konsorten/go-windows-terminal-sequences
   version: f55edac94c9bbba5d6182a4be46d86a2c9b5b50e
-- name: github.com/mailru/easyjson
-  version: d5b7844b561a7bc640052f1b935f7b800330d7e0
-  subpackages:
-  - buffer
-  - jlexer
-  - jwriter
-- name: github.com/opencontainers/go-digest
-  version: dd78d7521eee4ff6016d9b6273dc328308ac5a1c
-- name: github.com/pborman/uuid
-  version: ca53cad383cad2479bbba7f7a1a05797ec1386e4
-- name: github.com/PuerkitoBio/purell
-  version: 8a290539e2e8629dbc4e6bad948158f790ec31f4
-- name: github.com/PuerkitoBio/urlesc
-  version: 5bd2802263f21d8788851d5305584c82a5c75d7e
+- name: github.com/modern-go/concurrent
+  version: bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94
+- name: github.com/modern-go/reflect2
+  version: 94122c33edd36123c84d5368cfb2b69df93a0ec8
 - name: github.com/robfig/cron
-  version: b41be1df696709bb6395fe435af20370037c0b4c
+  version: ccba498c397bb90a9c84945bbb0f7af2d72b6309
 - name: github.com/sirupsen/logrus
-  version: 839c75faf7f98a33d445d181f3018b5c3409a45e
-- name: github.com/spf13/pflag
-  version: 9ff6c6923cfffbcd502984b8e0c80539a94968b7
+  version: d417be0fe654de640a82370515129985b407c7e3
 - name: github.com/stretchr/testify
   version: 3ebf1ddaeb260c4b1ae502a01c7844fa8c1fa0e9
   subpackages:
   - assert
-- name: github.com/ugorji/go
-  version: ded73eae5db7e7a0ef6f55aace87a2873c5d2b74
+- name: golang.org/x/crypto
+  version: c2843e01d9a2bc60bb26ad24e09734fdc2d9ec58
   subpackages:
-  - codec
+  - ssh/terminal
 - name: golang.org/x/net
-  version: f2499483f923065a842d38eb4c7f1927e6fc6e6d
+  version: 13f9640d40b9cc418fb53703dfbd177679788ceb
   subpackages:
   - context
   - context/ctxhttp
+  - http/httpguts
   - http2
   - http2/hpack
   - idna
-  - lex/httplex
 - name: golang.org/x/oauth2
-  version: 3c3a985cb79f52a3190fbc056984415ca6763d01
+  version: 0f29369cfe4552d0e4bcddc57cc75f4d7e672a33
   subpackages:
-  - google
   - internal
-  - jws
-  - jwt
 - name: golang.org/x/sys
-  version: d5e6a3e2c0ae16fc7480523ebcb7fd4dd3215489
+  version: fde4db37ae7ad8191b03d30d27f258b5291ae4e3
   subpackages:
   - unix
+  - windows
 - name: golang.org/x/text
-  version: 2910a502d2bf9e43193af9d68ca516529614eed3
+  version: 342b2e1fbaa52c93f31447ad2c6abc048c63e475
   subpackages:
-  - cases
-  - internal/tag
-  - language
-  - runes
   - secure/bidirule
-  - secure/precis
   - transform
   - unicode/bidi
   - unicode/norm
-  - width
+- name: golang.org/x/time
+  version: 9d24e82272b4f38b78bc8cff74fa936d31ccd8ef
+  subpackages:
+  - rate
 - name: google.golang.org/appengine
-  version: 4f7eeb5305a4ba1966344836ba4af9996b7b4e05
+  version: 54a98f90d1c46b7731eb8fb305d2a321c30ef610
   subpackages:
   - internal
-  - internal/app_identity
   - internal/base
   - internal/datastore
   - internal/log
-  - internal/modules
   - internal/remote_api
   - internal/urlfetch
   - urlfetch
 - name: gopkg.in/inf.v0
-  version: 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4
+  version: d2d2541c53f18d2a059457998ce2876cc8e67cbf
 - name: gopkg.in/yaml.v2
-  version: 53feefa2559fb8dfa8d81baad31be332c97d6c77
+  version: f221b8435cfb71e54062f6c6e99e9ade30b124d5
+- name: k8s.io/api
+  version: 4c9a86741a7ab3890dd9e0777e85d8eee48bf59c
+  subpackages:
+  - admissionregistration/v1
+  - admissionregistration/v1beta1
+  - apps/v1
+  - apps/v1beta1
+  - apps/v1beta2
+  - auditregistration/v1alpha1
+  - authentication/v1
+  - authentication/v1beta1
+  - authorization/v1
+  - authorization/v1beta1
+  - autoscaling/v1
+  - autoscaling/v2beta1
+  - autoscaling/v2beta2
+  - batch/v1
+  - batch/v1beta1
+  - batch/v2alpha1
+  - certificates/v1beta1
+  - coordination/v1
+  - coordination/v1beta1
+  - core/v1
+  - discovery/v1alpha1
+  - discovery/v1beta1
+  - events/v1beta1
+  - extensions/v1beta1
+  - flowcontrol/v1alpha1
+  - networking/v1
+  - networking/v1beta1
+  - node/v1alpha1
+  - node/v1beta1
+  - policy/v1beta1
+  - rbac/v1
+  - rbac/v1alpha1
+  - rbac/v1beta1
+  - scheduling/v1
+  - scheduling/v1alpha1
+  - scheduling/v1beta1
+  - settings/v1alpha1
+  - storage/v1
+  - storage/v1alpha1
+  - storage/v1beta1
 - name: k8s.io/apimachinery
-  version: c1b2a29e2e9d121b9b7d818cb0d84d8098783236
+  version: 79c2a76c473a20cdc4ce59cae4b72529b5d9d16b
   subpackages:
-  - pkg/labels
-  - pkg/selection
-  - pkg/util/sets
-  - pkg/util/validation
-- name: k8s.io/client-go
-  version: e121606b0d09b2e1c467183ee46217fa85a6b672
-  subpackages:
-  - discovery
-  - kubernetes
-  - kubernetes/typed/apps/v1beta1
-  - kubernetes/typed/authentication/v1beta1
-  - kubernetes/typed/authorization/v1beta1
-  - kubernetes/typed/autoscaling/v1
-  - kubernetes/typed/batch/v1
-  - kubernetes/typed/batch/v2alpha1
-  - kubernetes/typed/certificates/v1alpha1
-  - kubernetes/typed/core/v1
-  - kubernetes/typed/extensions/v1beta1
-  - kubernetes/typed/policy/v1beta1
-  - kubernetes/typed/rbac/v1alpha1
-  - kubernetes/typed/storage/v1beta1
-  - pkg/api
   - pkg/api/errors
-  - pkg/api/install
   - pkg/api/meta
-  - pkg/api/meta/metatypes
   - pkg/api/resource
-  - pkg/api/unversioned
-  - pkg/api/v1
-  - pkg/api/validation/path
-  - pkg/apimachinery
-  - pkg/apimachinery/announced
-  - pkg/apimachinery/registered
-  - pkg/apis/apps
-  - pkg/apis/apps/install
-  - pkg/apis/apps/v1beta1
-  - pkg/apis/authentication
-  - pkg/apis/authentication/install
-  - pkg/apis/authentication/v1beta1
-  - pkg/apis/authorization
-  - pkg/apis/authorization/install
-  - pkg/apis/authorization/v1beta1
-  - pkg/apis/autoscaling
-  - pkg/apis/autoscaling/install
-  - pkg/apis/autoscaling/v1
-  - pkg/apis/batch
-  - pkg/apis/batch/install
-  - pkg/apis/batch/v1
-  - pkg/apis/batch/v2alpha1
-  - pkg/apis/certificates
-  - pkg/apis/certificates/install
-  - pkg/apis/certificates/v1alpha1
-  - pkg/apis/extensions
-  - pkg/apis/extensions/install
-  - pkg/apis/extensions/v1beta1
-  - pkg/apis/policy
-  - pkg/apis/policy/install
-  - pkg/apis/policy/v1beta1
-  - pkg/apis/rbac
-  - pkg/apis/rbac/install
-  - pkg/apis/rbac/v1alpha1
-  - pkg/apis/storage
-  - pkg/apis/storage/install
-  - pkg/apis/storage/v1beta1
-  - pkg/auth/user
+  - pkg/apis/meta/v1
+  - pkg/apis/meta/v1/unstructured
   - pkg/conversion
   - pkg/conversion/queryparams
   - pkg/fields
-  - pkg/genericapiserver/openapi/common
   - pkg/labels
   - pkg/runtime
+  - pkg/runtime/schema
   - pkg/runtime/serializer
   - pkg/runtime/serializer/json
   - pkg/runtime/serializer/protobuf
@@ -225,42 +157,95 @@ imports:
   - pkg/runtime/serializer/streaming
   - pkg/runtime/serializer/versioning
   - pkg/selection
-  - pkg/third_party/forked/golang/reflect
-  - pkg/third_party/forked/golang/template
   - pkg/types
-  - pkg/util
-  - pkg/util/cert
   - pkg/util/clock
   - pkg/util/errors
-  - pkg/util/flowcontrol
   - pkg/util/framer
-  - pkg/util/integer
   - pkg/util/intstr
   - pkg/util/json
-  - pkg/util/jsonpath
-  - pkg/util/labels
+  - pkg/util/naming
   - pkg/util/net
-  - pkg/util/parsers
-  - pkg/util/rand
   - pkg/util/runtime
   - pkg/util/sets
-  - pkg/util/uuid
   - pkg/util/validation
   - pkg/util/validation/field
-  - pkg/util/wait
   - pkg/util/yaml
   - pkg/version
   - pkg/watch
-  - pkg/watch/versioned
-  - plugin/pkg/client/auth
-  - plugin/pkg/client/auth/gcp
-  - plugin/pkg/client/auth/oidc
+  - third_party/forked/golang/reflect
+- name: k8s.io/client-go
+  version: c68b62b1efa14564a47d67c07f013dc3553937b9
+  subpackages:
+  - core/v1
+  - discovery
+  - kubernetes
+  - kubernetes/scheme
+  - kubernetes/typed/admissionregistration/v1
+  - kubernetes/typed/admissionregistration/v1beta1
+  - kubernetes/typed/apps/v1
+  - kubernetes/typed/apps/v1beta1
+  - kubernetes/typed/apps/v1beta2
+  - kubernetes/typed/auditregistration/v1alpha1
+  - kubernetes/typed/authentication/v1
+  - kubernetes/typed/authentication/v1beta1
+  - kubernetes/typed/authorization/v1
+  - kubernetes/typed/authorization/v1beta1
+  - kubernetes/typed/autoscaling/v1
+  - kubernetes/typed/autoscaling/v2beta1
+  - kubernetes/typed/autoscaling/v2beta2
+  - kubernetes/typed/batch/v1
+  - kubernetes/typed/batch/v1beta1
+  - kubernetes/typed/batch/v2alpha1
+  - kubernetes/typed/certificates/v1beta1
+  - kubernetes/typed/coordination/v1
+  - kubernetes/typed/coordination/v1beta1
+  - kubernetes/typed/core/v1
+  - kubernetes/typed/discovery/v1alpha1
+  - kubernetes/typed/discovery/v1beta1
+  - kubernetes/typed/events/v1beta1
+  - kubernetes/typed/extensions/v1beta1
+  - kubernetes/typed/flowcontrol/v1alpha1
+  - kubernetes/typed/networking/v1
+  - kubernetes/typed/networking/v1beta1
+  - kubernetes/typed/node/v1alpha1
+  - kubernetes/typed/node/v1beta1
+  - kubernetes/typed/policy/v1beta1
+  - kubernetes/typed/rbac/v1
+  - kubernetes/typed/rbac/v1alpha1
+  - kubernetes/typed/rbac/v1beta1
+  - kubernetes/typed/scheduling/v1
+  - kubernetes/typed/scheduling/v1alpha1
+  - kubernetes/typed/scheduling/v1beta1
+  - kubernetes/typed/settings/v1alpha1
+  - kubernetes/typed/storage/v1
+  - kubernetes/typed/storage/v1alpha1
+  - kubernetes/typed/storage/v1beta1
+  - pkg/apis/clientauthentication
+  - pkg/apis/clientauthentication/v1alpha1
+  - pkg/apis/clientauthentication/v1beta1
+  - pkg/version
+  - plugin/pkg/client/auth/exec
   - rest
+  - rest/watch
+  - tools/clientcmd
   - tools/clientcmd/api
   - tools/metrics
+  - tools/reference
   - transport
+  - util/cert
+  - util/connrotation
+  - util/flowcontrol
+  - util/keyutil
+- name: k8s.io/klog
+  version: 2ca9ad30301bf30a8a6e0fa2110db6b8df699a91
+- name: k8s.io/utils
+  version: e782cd3c129fc98ee807f3c889c0f26eb7c9daf5
+  subpackages:
+  - integer
+- name: sigs.k8s.io/yaml
+  version: fd68e9863619f6ec2fdd8625fe1f02e7c877e480
 testImports:
 - name: github.com/pmezard/go-difflib
-  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
+  version: 792786c7400a136282c1664665ae0a8db921c6c2
   subpackages:
   - difflib

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,25 +1,21 @@
 package: github.com/target/pod-reaper
 import:
 - package: k8s.io/apimachinery
-  version: c1b2a29e2e9d121b9b7d818cb0d84d8098783236
+  version: =v0.17.0
   subpackages:
-    - /pkg/labels
-    - /pkg/selection
+  - pkg/labels
+  - pkg/selection
 - package: k8s.io/client-go
-  version: =v2.0.0
+  version: =v0.17.0
   subpackages:
-    - kubernetes
-    - pkg/api
-    - pkg/api/unversioned
-    - rest
-- package: k8s.io/client-go
-  version: =v2.0.0
-  subpackages:
-    - pkg/api/unversioned
+  - kubernetes
+  - core/v1
+  - rest
+  - tools/clientcmd
 - package: github.com/stretchr/testify
   version: ^1.1.4
 - package: github.com/robfig/cron
-  version: ^1.0.0
+  version: ^3.0.0
 - package: github.com/sirupsen/logrus
   version: ^1.0.0
 - package: github.com/docker/distribution
@@ -27,4 +23,4 @@ import:
 - package: github.com/joonix/log
   version: =v0.1
 - package: github.com/davecgh/go-spew
-  version: =v1.1.0
+  version: v1.1.1

--- a/reaper/reaper.go
+++ b/reaper/reaper.go
@@ -5,9 +5,10 @@ import (
 
 	"github.com/robfig/cron"
 	"github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/rest"
 )
 
@@ -46,7 +47,7 @@ func newReaper() reaper {
 func (reaper reaper) getPods() *v1.PodList {
 	coreClient := reaper.clientSet.CoreV1()
 	pods := coreClient.Pods(reaper.options.namespace)
-	listOptions := v1.ListOptions{}
+	listOptions := metav1.ListOptions{}
 	if reaper.options.labelExclusion != nil || reaper.options.labelRequirement != nil {
 		selector := labels.NewSelector()
 		if reaper.options.labelExclusion != nil {
@@ -70,7 +71,7 @@ func (reaper reaper) reapPod(pod v1.Pod, reasons []string) {
 		"pod":     pod.Name,
 		"reasons": reasons,
 	}).Info("reaping pod")
-	deleteOptions := &v1.DeleteOptions{
+	deleteOptions := &metav1.DeleteOptions{
 		GracePeriodSeconds: reaper.options.gracePeriod,
 	}
 	err := reaper.clientSet.CoreV1().Pods(pod.Namespace).Delete(pod.Name, deleteOptions)
@@ -93,10 +94,18 @@ func (reaper reaper) scytheCycle() {
 	}
 }
 
+func cronWithOptionalSeconds() *cron.Cron {
+	return cron.New(
+		cron.WithParser(
+			cron.NewParser(
+				// include optional seconds
+				cron.SecondOptional | cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow | cron.Descriptor)))
+}
+
 func (reaper reaper) harvest() {
 	runForever := reaper.options.runDuration == 0
-	schedule := cron.New()
-	err := schedule.AddFunc(reaper.options.schedule, func() {
+	schedule := cronWithOptionalSeconds()
+	_, err := schedule.AddFunc(reaper.options.schedule, func() {
 		reaper.scytheCycle()
 	})
 

--- a/rules/chaos.go
+++ b/rules/chaos.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"time"
 
-	"k8s.io/client-go/pkg/api/v1"
+	v1 "k8s.io/api/core/v1"
 )
 
 const envChaosChance = "CHAOS_CHANCE"

--- a/rules/chaos_test.go
+++ b/rules/chaos_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"k8s.io/client-go/pkg/api/v1"
+	"k8s.io/api/core/v1"
 )
 
 func TestChaosLoad(t *testing.T) {

--- a/rules/container_status.go
+++ b/rules/container_status.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"strings"
 
-	"k8s.io/client-go/pkg/api/v1"
+	"k8s.io/api/core/v1"
 )
 
 const envContainerStatus = "CONTAINER_STATUSES"

--- a/rules/container_status_test.go
+++ b/rules/container_status_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"k8s.io/client-go/pkg/api/v1"
+	"k8s.io/api/core/v1"
 )
 
 func testWaitContainerState(reason string) v1.ContainerState {

--- a/rules/duration.go
+++ b/rules/duration.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"time"
 
-	"k8s.io/client-go/pkg/api/v1"
+	"k8s.io/api/core/v1"
 )
 
 const envMaxDuration = "MAX_DURATION"

--- a/rules/duration_test.go
+++ b/rules/duration_test.go
@@ -6,14 +6,14 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"k8s.io/client-go/pkg/api/unversioned"
-	"k8s.io/client-go/pkg/api/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/api/core/v1"
 )
 
 func testDurationPod(startTime *time.Time) v1.Pod {
 	pod := v1.Pod{}
 	if startTime != nil {
-		setTime := unversioned.NewTime(*startTime)
+		setTime := metav1.NewTime(*startTime)
 		pod.Status.StartTime = &setTime
 	}
 	return pod

--- a/rules/pod_status.go
+++ b/rules/pod_status.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"strings"
 
-	"k8s.io/client-go/pkg/api/v1"
+	"k8s.io/api/core/v1"
 )
 
 const envPodStatus = "POD_STATUSES"

--- a/rules/pod_status_test.go
+++ b/rules/pod_status_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"k8s.io/client-go/pkg/api/v1"
+	"k8s.io/api/core/v1"
 )
 
 func testPodFromReason(reason string) v1.Pod {

--- a/rules/rules.go
+++ b/rules/rules.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 
 	"github.com/sirupsen/logrus"
-	"k8s.io/client-go/pkg/api/v1"
+	"k8s.io/api/core/v1"
 )
 
 // Rule is an interface defining the two functions needed for pod reaper to use the rule.

--- a/rules/rules_test.go
+++ b/rules/rules_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"io/ioutil"
-	"k8s.io/client-go/pkg/api/unversioned"
-	"k8s.io/client-go/pkg/api/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/api/core/v1"
 )
 
 func init() {
@@ -17,7 +17,7 @@ func init() {
 }
 
 func testPod() v1.Pod {
-	startTime := unversioned.NewTime(time.Now().Add(-2 * time.Minute))
+	startTime := metav1.NewTime(time.Now().Add(-2 * time.Minute))
 	return v1.Pod{
 		Status: v1.PodStatus{
 			StartTime: &startTime,

--- a/rules/unready.go
+++ b/rules/unready.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"time"
 
-	"k8s.io/client-go/pkg/api/v1"
+	"k8s.io/api/core/v1"
 )
 
 const envMaxUnready = "MAX_UNREADY"

--- a/rules/unready_test.go
+++ b/rules/unready_test.go
@@ -6,14 +6,14 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"k8s.io/client-go/pkg/api/unversioned"
-	"k8s.io/client-go/pkg/api/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func testUnreadyPod(lastTransitionTime *time.Time) v1.Pod {
 	pod := v1.Pod{}
 	if lastTransitionTime != nil {
-		setTime := unversioned.NewTime(*lastTransitionTime)
+		setTime := metav1.NewTime(*lastTransitionTime)
 		pod.Status.Conditions = []v1.PodCondition{
 			v1.PodCondition{
 				Type:               v1.PodReady,


### PR DESCRIPTION
resolves #53 (thanks for bringing it to my attention @jnavarro86  

There are a lot of details to this is #53, but the summary is that the cron library being used defaulted to a parser that used seconds (required) with day of week being optional. In newer versions of the library, the default parser still uses seconds, but includes better documentation and usability for making custom parse formats. I changed the parsing format to include optional seconds with required day-of-week, which is closer to the standard (differing only by inclusion of optional seconds).

This change should help alleviate any confusion.
`* * * * *` now complies with standard cron (starting with minutes)
`* * * * * *` starts with seconds and includes day of week

Before this change the behavior is actually:
`* * * * *` starts with seconds and does not include a day of week
`* * * * * *` starts with seconds and includes day of week

This is arguably a breaking change, or arguably just a bug fix. I'm going with the later given my own expectations of how it worked.

Along the way, I need to update one dependency, so I just updated a number. Credit to @jdharmon for doing the heavy lifting on dependency updates -- this should be compatible with the changes to #50 

What's included:
- update changelog (this had fallen slightly behind)
- update golang version (which I ended up doing for local testing)
- update the readme to document the new optional seconds on cron schedule
- update vender dependencies (this includes the k8s dependencies that have been renamed)
- use a custom parser to get optional seconds (for better compatibility and more accurate cron schedules)

What could "break"?

The case where things changes is when someone was using `* * * * *` . For anyone doing this, this PR will change that behavior to matching the standard cron format. If someone was intentionally relying on that being non-standard, then this might cause some minor pain in either the reaper running less frequently, or no longer being a valid cron format (which should error). I think this is reasonable to be considered as a fix rather than a breaking change.

Paging @slushpupie for a review :smile: 