### PR TITLE
added dry-run mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # pod-reaper: kills pods dead
 
+### 2.7.0
+- add `DRY_RUN` mode
+
 ### 2.6.0
 - adjusted cron `SCHEDULE` for optional seconds, non optional day of week
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,12 @@ A pod will be excluded from the pod-reaper if the pod has a metadata label has a
 
 These environment variables build a label selector that pods must match in order to be reaped. Use them the same way as you would `EXCLUDE_LABEL_KEY` and `EXCLUDE_LABEL_VALUES`.
 
+### `DRY_RUN`
+
+Deafult value: unset (which will behave as if it were set to "false")
+
+Acceptable values are 1, t, T, TRUE, true, True, 0, f, F, FALSE, false, False. Any other values will error. If the provided value is one of the "true" values then pod reaper will do select pods for reaper but will not actually kill any pods. Logging messages will reflect that a pod was selected for reaping and that pod was not killed because the reaper is in dry-run mode.
+
 ## Logging
 
 Pod reaper logs in JSON format using a logrus (https://github.com/sirupsen/logrus). 

--- a/reaper/options.go
+++ b/reaper/options.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -21,6 +22,7 @@ const envExcludeLabelKey = "EXCLUDE_LABEL_KEY"
 const envExcludeLabelValues = "EXCLUDE_LABEL_VALUES"
 const envRequireLabelKey = "REQUIRE_LABEL_KEY"
 const envRequireLabelValues = "REQUIRE_LABEL_VALUES"
+const envDryRun = "DRY_RUN"
 
 type options struct {
 	namespace        string
@@ -29,6 +31,7 @@ type options struct {
 	runDuration      time.Duration
 	labelExclusion   *labels.Requirement
 	labelRequirement *labels.Requirement
+	dryRun           bool
 	rules            rules.Rules
 }
 
@@ -109,6 +112,14 @@ func labelRequirement() (*labels.Requirement, error) {
 	return labelRequirement, nil
 }
 
+func dryRun() (bool, error) {
+	value, exists := os.LookupEnv(envDryRun)
+	if !exists {
+		return false, nil
+	}
+	return strconv.ParseBool(value)
+}
+
 func loadOptions() (options options, err error) {
 	options.namespace = namespace()
 	options.gracePeriod, err = gracePeriod()
@@ -125,6 +136,10 @@ func loadOptions() (options options, err error) {
 		return options, err
 	}
 	options.labelRequirement, err = labelRequirement()
+	if err != nil {
+		return options, err
+	}
+	options.dryRun, err = dryRun()
 	if err != nil {
 		return options, err
 	}

--- a/reaper/options_test.go
+++ b/reaper/options_test.go
@@ -5,9 +5,10 @@ import (
 	"testing"
 	"time"
 
+	"io/ioutil"
+
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
-	"io/ioutil"
 	"k8s.io/apimachinery/pkg/labels"
 )
 
@@ -148,6 +149,41 @@ func TestOptions(t *testing.T) {
 			assert.NoError(t, err)
 			assert.NotNil(t, requirement)
 			assert.Equal(t, "test-key in (test-value1,test-value2)", labels.NewSelector().Add(*requirement).String())
+		})
+	})
+	t.Run("dry-run", func(t *testing.T) {
+		t.Run("false", func(t *testing.T) {
+			os.Clearenv()
+			os.Setenv(envDryRun, "false")
+			dryRun, err := dryRun()
+			assert.NoError(t, err)
+			assert.False(t, dryRun)
+		})
+		t.Run("true", func(t *testing.T) {
+			os.Clearenv()
+			os.Setenv(envDryRun, "true")
+			dryRun, err := dryRun()
+			assert.NoError(t, err)
+			assert.True(t, dryRun)
+		})
+		t.Run("true by number", func(t *testing.T) {
+			os.Clearenv()
+			os.Setenv(envDryRun, "1")
+			dryRun, err := dryRun()
+			assert.NoError(t, err)
+			assert.True(t, dryRun)
+		})
+		t.Run("invalid", func(t *testing.T) {
+			os.Clearenv()
+			os.Setenv(envDryRun, "outside expected values")
+			_, err := dryRun()
+			assert.Error(t, err)
+		})
+		t.Run("not set", func(t *testing.T) {
+			os.Clearenv()
+			dryRun, err := dryRun()
+			assert.NoError(t, err)
+			assert.False(t, dryRun)
 		})
 	})
 }

--- a/rules/duration_test.go
+++ b/rules/duration_test.go
@@ -6,8 +6,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func testDurationPod(startTime *time.Time) v1.Pod {

--- a/rules/rules_test.go
+++ b/rules/rules_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"io/ioutil"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func init() {


### PR DESCRIPTION
resolves #55 

- adds a dry-run mode
- updates tests to go along with it

example log for when a pod would be reaped if not for dry-run mode:
```
$ kubectl -n reaper logs -f pod-reaper-55dc64c555-qhzlf 
{"level":"info","msg":"loaded rule: chaos chance .05","time":"2020-04-18T18:54:24Z"}
{"level":"info","msg":"pod would be reaped but pod-reaper is in dry-run mode","pod":"kube-scheduler-kind-control-plane","reasons":["was flagged for chaos"],"time":"2020-04-18T18:54:39Z"}
```

