### PR TITLE
Add Helm chart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .idea/
 vendor/
 pod-reaper.iml
-pod-reaper
 

--- a/chart/pod-reaper/Chart.yaml
+++ b/chart/pod-reaper/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+description: A Helm chart for pod-reaper
+name: pod-reaper
+version: 0.1.0
+home: https://github.com/target/pod-reaper

--- a/chart/pod-reaper/README.md
+++ b/chart/pod-reaper/README.md
@@ -1,0 +1,29 @@
+# Pod Reaper Helm Chart
+
+This is a helm templated deployment for pod-reaper.
+
+## Chart details
+
+This chart will install a target/pod-reaper for an arbitrary number of configurations. 
+
+Installing the chart.
+```bash
+helm upgrade --install <deployment name> . -f values.yaml --namespace <namespace>
+```
+
+| Parameter                        | Description                                        | Default                       |
+| -------------------------------- | -------------------------------------------------- | ----------------------------- |
+| `image.repository`               | Image file location                                | `target/pod-reaper`         |
+| `image.tag`                      | Image tag                                          | `2.8.0`                          |
+| `resources`                      | Provides resource limits                           | ```
+|                                  |                                                    | limits:
+|                                  |                                                    |   cpu: 30m
+|                                  |                                                    |   memory: 30Mi
+|                                  |                                                    | requests:
+|                                  |                                                    |   cpu: 20m
+|                                  |                                                    |   memory: 20Mi
+|                                  |                                                    | ```                         |
+
+...
+
+

--- a/chart/pod-reaper/templates/deployment.yaml
+++ b/chart/pod-reaper/templates/deployment.yaml
@@ -1,0 +1,39 @@
+{{- range $k, $v := .Values.reapers }}
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $.Chart.Name }}-{{ $k }}
+  namespace: {{$.Release.Namespace}}
+  labels:
+    chart: "{{ $.Chart.Name }}-{{ $.Chart.Version | replace "+" "_" }}"
+    app: {{ $.Chart.Name }}-{{ $k }}
+    release: "{{ $.Release.Name }}"
+    heritage: "{{ $.Release.Service }}"
+spec:
+  selector:
+    matchLabels:
+      app: {{ $.Chart.Name }}-{{ $k }}
+  template:
+    metadata:
+      labels:
+        app: {{ $.Chart.Name }}-{{ $k }}
+        release: {{ $.Release.Name }}
+    spec:
+      serviceAccountName: pod-reaper-service-account
+      containers:
+        - name: {{ $.Chart.Name }}
+          image: "{{ $.Values.image.repository }}:{{ $.Values.image.tag }}"
+          env:
+          {{- range $envkey, $envvalue := $v }}
+          {{- if $envvalue }}
+            - name: {{ upper $envkey}}
+              value: "{{$envvalue}}"
+          {{- end }}
+          {{- end }}
+          resources:
+{{ toYaml $.Values.resources | indent 12 }}
+
+---
+
+{{- end -}}

--- a/chart/pod-reaper/templates/rbac.yaml
+++ b/chart/pod-reaper/templates/rbac.yaml
@@ -1,0 +1,33 @@
+---
+# service account for running pod-reaper
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pod-reaper-service-account
+  namespace: {{.Release.Namespace}}
+
+---
+# minimal permissions required for running pod-reaper at cluster level
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: pod-reaper-cluster-role
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["list", "delete"]
+
+---
+# binding the above cluster role (permissions) to the above service account
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: pod-reaper-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: pod-reaper-cluster-role
+subjects:
+- kind: ServiceAccount
+  name: pod-reaper-service-account
+  namespace: {{.Release.Namespace}}

--- a/chart/pod-reaper/values.yaml
+++ b/chart/pod-reaper/values.yaml
@@ -5,26 +5,29 @@ image:
   repository: target/pod-reaper
   tag: 2.8.0
 
-reapers:
-  default:
-    namespace: "" # ie all
-    grace_period: 10m
-    schedule: "@every 1m"
-    run_duration: "0s" # ie indefinitely
-    exclude_label_key: ""
-    exclude_label_values: ""
-    require_label_key: ""
-    require_label_values: ""
-    require_annotation_key: ""
-    require_annotation_values: ""
-    dry_run: "false"
-    log_level: "Info"
-    log_format: "Logrus"
-    chaos_chance: ""
-    container_statuses: ""
-    pod_statuses: ""
-    max_duration: ""
-    max_unready: ""
+# A set of named reapers
+# Example config:
+#
+#  test-reaper:
+#    namespace: "" # ie all
+#    grace_period: 10m
+#    schedule: "@every 1m"
+#    run_duration: "0s" # ie indefinitely
+#    exclude_label_key: ""
+#    exclude_label_values: ""
+#    require_label_key: ""
+#    require_label_values: ""
+#    require_annotation_key: ""
+#    require_annotation_values: ""
+#    dry_run: "false"
+#    log_level: "Info"
+#    log_format: "Logrus"
+#    chaos_chance: ""
+#    container_statuses: ""
+#    pod_statuses: ""
+#    max_duration: ""
+#    max_unready: ""
+reapers: {}
 
 resources:
   limits:

--- a/chart/pod-reaper/values.yaml
+++ b/chart/pod-reaper/values.yaml
@@ -1,0 +1,35 @@
+# Default values for chart.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+image:
+  repository: target/pod-reaper
+  tag: 2.8.0
+
+reapers:
+  default:
+    namespace: "" # ie all
+    grace_period: 10m
+    schedule: "@every 1m"
+    run_duration: "0s" # ie indefinitely
+    exclude_label_key: ""
+    exclude_label_values: ""
+    require_label_key: ""
+    require_label_values: ""
+    require_annotation_key: ""
+    require_annotation_values: ""
+    dry_run: "false"
+    log_level: "Info"
+    log_format: "Logrus"
+    chaos_chance: ""
+    container_statuses: ""
+    pod_statuses: ""
+    max_duration: ""
+    max_unready: ""
+
+resources:
+  limits:
+    cpu: 30m
+    memory: 30Mi
+  requests:
+    cpu: 20m
+    memory: 20Mi


### PR DESCRIPTION
Here is a helm chart for pod-reaper. It works great for us. It is fully working, and just needs more documentation. I thought you would have more thoughts on that.

Features:

- Helm chart install
- Cluster wide ServiceAccount RBAC
- Allows image tag override
- Allows all config settings
- Allows multiple reapers in one release
 
Example `values.yaml`:

```
reapers:
  foo-reaper:
    namespace: "foo"
    grace_period: 10m
    max_duration: "10m"
  bar-reaper:
    namespace: "bar"
    grace_period: 1h
    max_duration: "30m"
```
