### PR TITLE
update building docker container base to golang 1.1.15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build
-FROM golang:1.14 AS build
+FROM golang:1.15 AS build
 WORKDIR /go/src/github.com/target/pod-reaper
 ENV CGO_ENABLED=0 GOOS=linux
 COPY ./ ./


### PR DESCRIPTION
- Updating the base build docker container to golang 1.1.15

I found no incompatibilities from previously used golang version. Everything built and worked as I would expect it to!