### PR TITLE
added a max-pods option

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,12 @@ Deafult value: unset (which will behave as if it were set to "false")
 
 Acceptable values are 1, t, T, TRUE, true, True, 0, f, F, FALSE, false, False. Any other values will error. If the provided value is one of the "true" values then pod reaper will do select pods for reaper but will not actually kill any pods. Logging messages will reflect that a pod was selected for reaping and that pod was not killed because the reaper is in dry-run mode.
 
+### `MAX_PODS`
+
+Default value: unset (which will behave as if it were set to "0")
+
+Acceptable values are positive integers. Negative integers will evaluate to 0 and any other values will error. This can be useful to prevent too many pods being killed in one run. Logging messages will reflect that a pod was selected for reaping and that pod was not killed because too many pods were reaped already.
+
 ## Logging
 
 Pod reaper logs in JSON format using a logrus (https://github.com/sirupsen/logrus). 

--- a/chart/pod-reaper/values.yaml
+++ b/chart/pod-reaper/values.yaml
@@ -20,6 +20,7 @@ image:
 #    require_annotation_key: ""
 #    require_annotation_values: ""
 #    dry_run: "false"
+#    max_pods: "0"
 #    log_level: "Info"
 #    log_format: "Logrus"
 #    chaos_chance: ""

--- a/reaper/options.go
+++ b/reaper/options.go
@@ -25,6 +25,7 @@ const envRequireLabelValues = "REQUIRE_LABEL_VALUES"
 const envRequireAnnotationKey = "REQUIRE_ANNOTATION_KEY"
 const envRequireAnnotationValues = "REQUIRE_ANNOTATION_VALUES"
 const envDryRun = "DRY_RUN"
+const envMaxPods = "MAX_PODS"
 const envEvict = "EVICT"
 
 type options struct {
@@ -36,6 +37,7 @@ type options struct {
 	labelRequirement      *labels.Requirement
 	annotationRequirement *labels.Requirement
 	dryRun                bool
+	maxPods               int
 	rules                 rules.Rules
 	evict                 bool
 }
@@ -143,6 +145,24 @@ func dryRun() (bool, error) {
 	return strconv.ParseBool(value)
 }
 
+func maxPods() (int, error) {
+	value, exists := os.LookupEnv(envMaxPods)
+	if !exists {
+		return 0, nil
+	}
+
+	v, err := strconv.Atoi(value)
+	if err != nil {
+		return 0, err
+	}
+
+	if v < 0 {
+		return 0, nil
+	}
+
+	return v, nil
+}
+
 func evict() (bool, error) {
 	value, exists := os.LookupEnv(envEvict)
 	if !exists {
@@ -175,6 +195,10 @@ func loadOptions() (options options, err error) {
 		return options, err
 	}
 	options.dryRun, err = dryRun()
+	if err != nil {
+		return options, err
+	}
+	options.maxPods, err = maxPods()
 	if err != nil {
 		return options, err
 	}

--- a/reaper/options_test.go
+++ b/reaper/options_test.go
@@ -222,6 +222,34 @@ func TestOptions(t *testing.T) {
 			assert.False(t, dryRun)
 		})
 	})
+	t.Run("max-pods", func(t *testing.T) {
+		t.Run("invalid", func(t *testing.T) {
+			os.Clearenv()
+			os.Setenv(envMaxPods, "not a number")
+			_, err := maxPods()
+			assert.Error(t, err)
+		})
+		t.Run("negative", func(t *testing.T) {
+			os.Clearenv()
+			os.Setenv(envMaxPods, "-123")
+			maxPods, err := maxPods()
+			assert.NoError(t, err)
+			assert.Equal(t, 0, maxPods)
+		})
+		t.Run("positive", func(t *testing.T) {
+			os.Clearenv()
+			os.Setenv(envMaxPods, "123")
+			maxPods, err := maxPods()
+			assert.NoError(t, err)
+			assert.Equal(t, 123, maxPods)
+		})
+		t.Run("not set", func(t *testing.T) {
+			os.Clearenv()
+			maxPods, err := maxPods()
+			assert.NoError(t, err)
+			assert.Equal(t, 0, maxPods)
+		})
+	})
 }
 
 func TestOptionsLoad(t *testing.T) {


### PR DESCRIPTION
to limit the amount of pods being reaped in a single run

Example log when too many pods were chosen to be reaped:

```
{"level":"debug","msg":"starting reap cycle","time":"2021-08-24T08:57:33Z"}
{"level":"info","msg":"reaping pod","pod":"my-deploymeny-69bf6ff5f6-nv7gx","reasons":["has been running for 21h24m6.158295489s"],"time":"2021-08-24T08:57:33Z"}
{"level":"info","maxPods":1,"msg":"not reaping pod","pod":"my-deploymeny-69bf6ff5f6-mmvk2","reaped":1,"reason":["has been running for 21h27m43.158365657s"],"time":"2021-08-24T08:57:33Z"}
{"level":"info","maxPods":1,"msg":"not reaping pod","pod":"my-deploymeny-69bf6ff5f6-ns84z","reaped":1,"reason":["has been running for 21h33m49.783874147s"],"time":"2021-08-24T08:57:33Z"}
```