### PR TITLE
Fixing namespace land apiVersion the default rbac template

### DIFF
--- a/chart/pod-reaper/templates/rbac.yaml
+++ b/chart/pod-reaper/templates/rbac.yaml
@@ -9,7 +9,7 @@ metadata:
 ---
 # minimal permissions required for running pod-reaper at cluster level
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: pod-reaper-cluster-role
 rules:
@@ -22,7 +22,7 @@ rules:
 
 ---
 # binding the above cluster role (permissions) to the above service account
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: pod-reaper-role-binding

--- a/chart/pod-reaper/templates/rbac.yaml
+++ b/chart/pod-reaper/templates/rbac.yaml
@@ -26,6 +26,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: pod-reaper-role-binding
+  namespace: {{.Release.Namespace}}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -33,4 +34,3 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: pod-reaper-service-account
-  namespace: {{.Release.Namespace}}


### PR DESCRIPTION
While trying to follow the documentation and install the chart/pod-reaper I got the errors below.

**❯ helm install --dry-run pod-reaper --namespace=default chart/pod-reaper**
Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: ValidationError(ClusterRoleBinding): unknown field "namespace" in io.k8s.api.rbac.v1.ClusterRoleBinding

**❯ helm install --dry-run pod-reaper --namespace=default chart/pod-reaper**
Error: unable to build kubernetes objects from release manifest: [unable to recognize "": no matches for kind "ClusterRole" in version "rbac.authorization.k8s.io/v1beta1", unable to recognize "": no matches for kind "Cl
usterRoleBinding" in version "rbac.authorization.k8s.io/v1beta1"]

For the first I change the namespace location in the template and I changed the apiVersion in the rbac template.
after those changes I was bale to install the chart w