### PR TITLE
Updating RBAC to version V1 to remove warning deprecation message

### DIFF
--- a/chart/pod-reaper/templates/rbac.yaml
+++ b/chart/pod-reaper/templates/rbac.yaml
@@ -9,7 +9,7 @@ metadata:
 ---
 # minimal permissions required for running pod-reaper at cluster level
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: pod-reaper-cluster-role
 rules:
@@ -22,7 +22,7 @@ rules:
 
 ---
 # binding the above cluster role (permissions) to the above service account
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: pod-reaper-role-binding

--- a/examples/cluster-permissions.yml
+++ b/examples/cluster-permissions.yml
@@ -19,7 +19,7 @@ metadata:
 ---
 # minimal permissions required for running pod-reaper at cluster level
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: pod-reaper-cluster-role
 rules:
@@ -29,7 +29,7 @@ rules:
 
 ---
 # binding the above cluster role (permissions) to the above service account
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: pod-reaper-role-binding

--- a/examples/complex-deployment.yml
+++ b/examples/complex-deployment.yml
@@ -18,7 +18,7 @@ metadata:
 ---
 # minimal permissions required for running pod-reaper at cluster level
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: pod-reaper-cluster-role
 rules:
@@ -28,7 +28,7 @@ rules:
 
 ---
 # binding the above cluster role (permissions) to the above service account
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: pod-reaper-role-binding

--- a/examples/namespace-permissions.yml
+++ b/examples/namespace-permissions.yml
@@ -19,7 +19,7 @@ metadata:
 ---
 # minimal permissions required for running pod-reaper
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: reaper
   name: pod-reaper-role
@@ -30,7 +30,7 @@ rules:
 
 ---
 # binding the above role (permissions) to the above service account
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: pod-reaper-role-binding

--- a/examples/one-time-run.yml
+++ b/examples/one-time-run.yml
@@ -19,7 +19,7 @@ metadata:
 ---
 # minimal permissions required for running pod-reaper at cluster level
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: pod-reaper-cluster-role
 rules:
@@ -29,7 +29,7 @@ rules:
 
 ---
 # binding the above cluster role (permissions) to the above service account
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: pod-reaper-role-binding


### PR DESCRIPTION
Fix #75

This MR was created to remove the warnings related to API deprecation like the ones below:
`W1206 09:54:41.302957    6924 warnings.go:70] rbac.authorization.k8s.io/v1beta1 ClusterRole is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 ClusterRole
W1206 09:54:41.502812    6924 warnings.go:70] rbac.authorization.k8s.io/v1beta1 ClusterRoleBinding is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 ClusterRoleBinding
W1206 09:54:42.119382    6924 warnings.go:70] rbac.authorization.k8s.io/v1beta1 ClusterRole is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 ClusterRole
W1206 09:54:42.306488    6924 warnings.go:70] rbac.authorization.k8s.io/v1beta1 ClusterRoleBinding is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 ClusterRoleBinding`

