### PR TITLE
Pod ordering

### DIFF
--- a/examples/pod-sorting-strategy.yml
+++ b/examples/pod-sorting-strategy.yml
@@ -1,0 +1,85 @@
+# example configuration with permission for running pod-reaper against
+# an entire cluster
+
+---
+# namespace for the reaper
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: reaper
+
+---
+# service account for running pod-reaper
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pod-reaper-service-account
+  namespace: reaper
+
+---
+# minimal permissions required for running pod-reaper at cluster level
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: pod-reaper-cluster-role
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["list", "delete"]
+
+---
+# binding the above cluster role (permissions) to the above service account
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: pod-reaper-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: pod-reaper-cluster-role
+subjects:
+- kind: ServiceAccount
+  name: pod-reaper-service-account
+  namespace: reaper
+
+---
+# a basic pod-reaper deployment
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pod-reaper
+  namespace: reaper # namespace matches above
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: pod-reaper
+  template:
+    metadata:
+      labels:
+        app: pod-reaper
+    spec:
+      serviceAccount: pod-reaper-service-account # service account from above
+      containers:
+      - name: chaos
+        image: brianberzins/pod-reaper:alpha
+        resources:
+          limits:
+            cpu: 30m
+            memory: 30Mi
+          requests:
+            cpu: 20m
+            memory: 20Mi
+        env:
+          - name: EXCLUDE_LABEL_KEY
+            value: "tier"
+          - name: EXCLUDE_LABEL_VALUES
+            value: "control-plane"
+          - name: SCHEDULE
+            value: "@every 20s"
+          - name: CHAOS_CHANCE
+            value: "1"
+          - name: MAX_PODS
+            value: "1"
+          - name: POD_SORTING_STRATEGY
+            value: "oldest-first"

--- a/reaper/options.go
+++ b/reaper/options.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	v1 "k8s.io/api/core/v1"
 	"os"
@@ -166,7 +167,14 @@ func maxPods() (int, error) {
 }
 
 func podSortingStrategy() (func([]v1.Pod), error) {
-	return func(pods []v1.Pod) {}, nil
+	sortingStrategy, present := os.LookupEnv(envPodSortingStrategy)
+	if !present {
+		return func(pods []v1.Pod) {}, nil
+	}
+	switch sortingStrategy {
+	default:
+		return nil, errors.New("unknown pod sorting strategy")
+	}
 }
 
 func evict() (bool, error) {

--- a/reaper/options.go
+++ b/reaper/options.go
@@ -191,7 +191,7 @@ func podSortingStrategy() (func([]v1.Pod), error) {
 				return pods[i].Status.StartTime.Unix() < pods[j].Status.StartTime.Unix()
 			})
 		}, nil
-	case "newest-first":
+	case "youngest-first":
 		return func(pods []v1.Pod) {
 			sort.Slice(pods, func(i, j int) bool {
 				if pods[i].Status.StartTime == nil {

--- a/reaper/options.go
+++ b/reaper/options.go
@@ -173,7 +173,6 @@ func podSortingStrategy() (func([]v1.Pod), error) {
 		return func(pods []v1.Pod) {}, nil
 	}
 
-	//rand.Shuffle(len(a), func(i, j int) { a[i], a[j] = a[j], a[i] })
 	switch sortingStrategy {
 	case "random":
 		return func(pods []v1.Pod) {

--- a/reaper/options.go
+++ b/reaper/options.go
@@ -180,7 +180,7 @@ func getPodDeletionCost(pod v1.Pod) int32 {
 	return int32(cost)
 }
 
-func defaultSort(pods []v1.Pod) {}
+func defaultSort([]v1.Pod) {}
 
 func randomSort(pods []v1.Pod) {
 	rand.Shuffle(len(pods), func(i, j int) { pods[i], pods[j] = pods[j], pods[i] })

--- a/reaper/options.go
+++ b/reaper/options.go
@@ -191,6 +191,18 @@ func podSortingStrategy() (func([]v1.Pod), error) {
 				return pods[i].Status.StartTime.Unix() < pods[j].Status.StartTime.Unix()
 			})
 		}, nil
+	case "newest-first":
+		return func(pods []v1.Pod) {
+			sort.Slice(pods, func(i, j int) bool {
+				if pods[i].Status.StartTime == nil {
+					return false
+				}
+				if pods[j].Status.StartTime == nil {
+					return true
+				}
+				return pods[j].Status.StartTime.Unix() < pods[i].Status.StartTime.Unix()
+			})
+		}, nil
 	default:
 		return nil, errors.New("unknown pod sorting strategy")
 	}

--- a/reaper/options.go
+++ b/reaper/options.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	v1 "k8s.io/api/core/v1"
+	"math/rand"
 	"os"
 	"strconv"
 	"strings"
@@ -171,7 +172,13 @@ func podSortingStrategy() (func([]v1.Pod), error) {
 	if !present {
 		return func(pods []v1.Pod) {}, nil
 	}
+
+	//rand.Shuffle(len(a), func(i, j int) { a[i], a[j] = a[j], a[i] })
 	switch sortingStrategy {
+	case "random":
+		return func(pods []v1.Pod) {
+			rand.Shuffle(len(pods), func(i, j int) { pods[i], pods[j] = pods[j], pods[i] })
+		}, nil
 	default:
 		return nil, errors.New("unknown pod sorting strategy")
 	}

--- a/reaper/options.go
+++ b/reaper/options.go
@@ -43,6 +43,7 @@ type options struct {
 	annotationRequirement *labels.Requirement
 	dryRun                bool
 	maxPods               int
+	podSortingStrategy    func([]v1.Pod)
 	rules                 rules.Rules
 	evict                 bool
 }
@@ -235,44 +236,37 @@ func evict() (bool, error) {
 
 func loadOptions() (options options, err error) {
 	options.namespace = namespace()
-	options.gracePeriod, err = gracePeriod()
-	if err != nil {
+	if options.gracePeriod, err = gracePeriod(); err != nil {
 		return options, err
 	}
 	options.schedule = schedule()
-	options.runDuration, err = runDuration()
-	if err != nil {
+	if options.runDuration, err = runDuration(); err != nil {
 		return options, err
 	}
-	options.labelExclusion, err = labelExclusion()
-	if err != nil {
+	if options.labelExclusion, err = labelExclusion(); err != nil {
 		return options, err
 	}
-	options.labelRequirement, err = labelRequirement()
-	if err != nil {
+	if options.labelRequirement, err = labelRequirement(); err != nil {
 		return options, err
 	}
-	options.annotationRequirement, err = annotationRequirement()
-	if err != nil {
+	if options.annotationRequirement, err = annotationRequirement(); err != nil {
 		return options, err
 	}
-	options.dryRun, err = dryRun()
-	if err != nil {
+	if options.dryRun, err = dryRun(); err != nil {
 		return options, err
 	}
-	options.maxPods, err = maxPods()
-	if err != nil {
+	if options.maxPods, err = maxPods(); err != nil {
 		return options, err
 	}
-
-	options.evict, err = evict()
-	if err != nil {
+	if options.podSortingStrategy, err = podSortingStrategy(); err != nil {
+		return options, err
+	}
+	if options.evict, err = evict(); err != nil {
 		return options, err
 	}
 
 	// rules
-	options.rules, err = rules.LoadRules()
-	if err != nil {
+	if options.rules, err = rules.LoadRules(); err != nil {
 		return options, err
 	}
 	return options, nil

--- a/reaper/options.go
+++ b/reaper/options.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	v1 "k8s.io/api/core/v1"
 	"os"
 	"strconv"
 	"strings"
@@ -26,6 +27,7 @@ const envRequireAnnotationKey = "REQUIRE_ANNOTATION_KEY"
 const envRequireAnnotationValues = "REQUIRE_ANNOTATION_VALUES"
 const envDryRun = "DRY_RUN"
 const envMaxPods = "MAX_PODS"
+const envPodSortingStrategy = "POD_SORTING_STRATEGY"
 const envEvict = "EVICT"
 
 type options struct {
@@ -161,6 +163,10 @@ func maxPods() (int, error) {
 	}
 
 	return v, nil
+}
+
+func podSortingStrategy() (func([]v1.Pod), error) {
+	return func(pods []v1.Pod) {}, nil
 }
 
 func evict() (bool, error) {

--- a/reaper/options_test.go
+++ b/reaper/options_test.go
@@ -313,6 +313,7 @@ func TestOptions(t *testing.T) {
 			rand.Seed(2) // magic seed to force switch
 			sorter(subject)
 			assert.NotEqual(t, testPodList(), subject)
+			assert.ElementsMatch(t, testPodList(), subject)
 		})
 		t.Run("oldest-first", func(t *testing.T) {
 			os.Clearenv()
@@ -325,6 +326,20 @@ func TestOptions(t *testing.T) {
 			assert.Equal(t, "corgi", subject[0].ObjectMeta.Name)
 			assert.Equal(t, "bearded-dragon", subject[1].ObjectMeta.Name)
 			assert.Equal(t, "nil-start-time", subject[2].ObjectMeta.Name)
+			assert.ElementsMatch(t, testPodList(), subject)
+		})
+		t.Run("newest-first", func(t *testing.T) {
+			os.Clearenv()
+			os.Setenv(envPodSortingStrategy, "newest-first")
+			sorter, err := podSortingStrategy()
+			assert.NotNil(t, sorter)
+			assert.NoError(t, err)
+			subject := testPodList()
+			sorter(subject)
+			assert.Equal(t, "bearded-dragon", subject[0].ObjectMeta.Name)
+			assert.Equal(t, "corgi", subject[1].ObjectMeta.Name)
+			assert.Equal(t, "nil-start-time", subject[2].ObjectMeta.Name)
+			assert.ElementsMatch(t, testPodList(), subject)
 		})
 	})
 }

--- a/reaper/options_test.go
+++ b/reaper/options_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"os"
 	"testing"
 	"time"
@@ -14,6 +16,23 @@ import (
 
 func init() {
 	logrus.SetOutput(ioutil.Discard)
+}
+
+func testPodList() []v1.Pod {
+	return []v1.Pod{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "bearded-dragon",
+				Annotations: map[string]string{"example/key": "lizard"},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "corgi",
+				Annotations: map[string]string{"example/key": "not-lizard"},
+			},
+		},
+	}
 }
 
 func TestOptions(t *testing.T) {
@@ -248,6 +267,17 @@ func TestOptions(t *testing.T) {
 			maxPods, err := maxPods()
 			assert.NoError(t, err)
 			assert.Equal(t, 0, maxPods)
+		})
+	})
+	t.Run("pod-sorting", func(t *testing.T) {
+		t.Run("default", func(t *testing.T) {
+			os.Clearenv()
+			sorter, err := podSortingStrategy()
+			assert.NotNil(t, sorter)
+			assert.NoError(t, err)
+			subject := testPodList()
+			sorter(subject)
+			assert.Equal(t, testPodList(), subject)
 		})
 	})
 }

--- a/reaper/options_test.go
+++ b/reaper/options_test.go
@@ -279,6 +279,12 @@ func TestOptions(t *testing.T) {
 			sorter(subject)
 			assert.Equal(t, testPodList(), subject)
 		})
+		t.Run("invalid", func(t *testing.T) {
+			os.Clearenv()
+			os.Setenv(envPodSortingStrategy, "not a valid sorting strategy")
+			_, err := podSortingStrategy()
+			assert.Error(t, err)
+		})
 	})
 }
 

--- a/reaper/options_test.go
+++ b/reaper/options_test.go
@@ -328,9 +328,9 @@ func TestOptions(t *testing.T) {
 			assert.Equal(t, "nil-start-time", subject[2].ObjectMeta.Name)
 			assert.ElementsMatch(t, testPodList(), subject)
 		})
-		t.Run("newest-first", func(t *testing.T) {
+		t.Run("youngest-first", func(t *testing.T) {
 			os.Clearenv()
-			os.Setenv(envPodSortingStrategy, "newest-first")
+			os.Setenv(envPodSortingStrategy, "youngest-first")
 			sorter, err := podSortingStrategy()
 			assert.NotNil(t, sorter)
 			assert.NoError(t, err)

--- a/reaper/options_test.go
+++ b/reaper/options_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"math/rand"
 	"os"
 	"testing"
 	"time"
@@ -284,6 +285,17 @@ func TestOptions(t *testing.T) {
 			os.Setenv(envPodSortingStrategy, "not a valid sorting strategy")
 			_, err := podSortingStrategy()
 			assert.Error(t, err)
+		})
+		t.Run("random", func(t *testing.T) {
+			os.Clearenv()
+			os.Setenv(envPodSortingStrategy, "random")
+			sorter, err := podSortingStrategy()
+			assert.NotNil(t, sorter)
+			assert.NoError(t, err)
+			subject := testPodList()
+			rand.Seed(2) // magic seed to force switch
+			sorter(subject)
+			assert.NotEqual(t, testPodList(), subject)
 		})
 	})
 }

--- a/reaper/reaper.go
+++ b/reaper/reaper.go
@@ -60,6 +60,10 @@ func (reaper reaper) getPods() *v1.PodList {
 		listOptions.LabelSelector = selector.String()
 	}
 	podList, err := pods.List(listOptions)
+
+	// get a sorting strategy
+	// sort by that strategy
+
 	if err != nil {
 		logrus.WithError(err).Panic("unable to get pods from the cluster")
 		panic(err)

--- a/reaper/reaper.go
+++ b/reaper/reaper.go
@@ -60,9 +60,7 @@ func (reaper reaper) getPods() *v1.PodList {
 		listOptions.LabelSelector = selector.String()
 	}
 	podList, err := pods.List(listOptions)
-
-	// get a sorting strategy
-	// sort by that strategy
+	reaper.options.podSortingStrategy(podList.Items)
 
 	if err != nil {
 		logrus.WithError(err).Panic("unable to get pods from the cluster")

--- a/rules/rules.go
+++ b/rules/rules.go
@@ -10,11 +10,11 @@ import (
 // Rule is an interface defining the two functions needed for pod reaper to use the rule.
 type Rule interface {
 
-	// load attempts to load the load and returns whether or the not the rule was loaded, a message that will be logged
+	// load attempts to load the load and returns whether the rule was loaded, a message that will be logged
 	// when the rule is loaded, and any error that may have occurred during the load.
 	load() (bool, string, error)
 
-	// ShouldReap takes a pod and returns whether or not the pod should be reaped based on this rule and a message that
+	// ShouldReap takes a pod and returns whether the pod should be reaped based on this rule and a message that
 	// will be logged when the pod is selected for reaping.
 	ShouldReap(pod v1.Pod) (bool, string)
 }
@@ -24,7 +24,7 @@ type Rules struct {
 	LoadedRules []Rule
 }
 
-// LoadRules load all of the rules based on their own implementations
+// LoadRules load all the rules based on their own implementations
 func LoadRules() (Rules, error) {
 	// load all possible rules
 	rules := []Rule{
@@ -45,14 +45,14 @@ func LoadRules() (Rules, error) {
 			loadedRules = append(loadedRules, rule)
 		}
 	}
-	// return an err if no rules where loaded
+	// return an error if no rules where loaded
 	if len(loadedRules) == 0 {
 		return Rules{LoadedRules: loadedRules}, errors.New("no rules were loaded")
 	}
 	return Rules{LoadedRules: loadedRules}, nil
 }
 
-// ShouldReap takes a pod and return whether or not the pod should be reaped based on this rule.
+// ShouldReap takes a pod and return whether the pod should be reaped based on this rule.
 // Also includes a message describing why the pod was flagged for reaping.
 func (rules Rules) ShouldReap(pod v1.Pod) (bool, []string) {
 	var reasons []string


### PR DESCRIPTION
Implemented optional pod sorting in the case where pods want to be sorted before deletion. This would primarily be used when max_pods is set, providing some control of which pods get deleted first in the case where the reaper won't reap all of them.

Strategies implement:
- oldest first
- youngest first
- pod deletion cost
- random