### PR TITLE
cannot create resource \"pods/eviction\" in API group

### DIFF
--- a/examples/cluster-permissions.yml
+++ b/examples/cluster-permissions.yml
@@ -26,6 +26,9 @@ rules:
 - apiGroups: [""]
   resources: ["pods"]
   verbs: ["list", "delete"]
+- apiGroups: [""]
+  resources: ["pods/eviction"]
+  verbs: ["create"]
 
 ---
 # binding the above cluster role (permissions) to the above service account


### PR DESCRIPTION
actually just followed this PR in an unrelated kubernetes repo: https://github.com/kubernetes-sigs/descheduler/pull/64/files

was getting an error:

```
{"error":"pods \"{REDACTED}\" is forbidden: User \"system:serviceaccount:{REDACTED}:pod-reaper-service-account\" cannot create resource \"pods/eviction\" in API group \"\" in the namespace \"uat-nucleus\"","message":"unable to delete podpods \"{REDACTED}\" is forbidden: User \"system:serviceaccount:{REDACTED}pod-reaper-service-account\" cannot create resource \"pods/eviction\" in API group \"\" in the namespace \"{REDACTED}s\"","pod":"{REDACTED}","severity":"warn","time":"2023-08-23T00:05:01.423715449Z"}", "logtag":"F", "stream":"stderr", "tag":"{REDACTED}T"}
```